### PR TITLE
Rename backend go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TeamStrata/backend
+module github.com/TeamStrata/strata
 
 go 1.24.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/TeamStrata/backend v0.0.0-20250313010433-c63dcca4e76e h1:IhCcAWts/SYH6WbYKlkdhJdveUv+5qtTtHgSCA/5PuY=
+github.com/TeamStrata/backend v0.0.0-20250313010433-c63dcca4e76e/go.mod h1:lxOjfjfrqhTG71hMkNiFHxfT/jcqyfKkTHgr3jVJr+M=
 github.com/bytedance/sonic v1.12.6 h1:/isNmCUF2x3Sh8RAp/4mh4ZGkcFAX/hLrzrK3AvpRzk=
 github.com/bytedance/sonic v1.12.6/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
@@ -7,7 +9,6 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/TeamStrata/backend/api"
+	"github.com/TeamStrata/strata/api"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
Rename backend Go module from `github.com/TeamStrata/backend` to `github.com/TeamStrata/strata`.

Resolves issue #4.