### PR TITLE
Saving queries

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-CONNECTION_STRING: "postgresql://strata:atarts@127.0.0.1/strata"
+CONNECTION_STRING: "postgresql://strata:atarts@strata_psql/strata"

--- a/.github/workflows/go_unit_test.yml
+++ b/.github/workflows/go_unit_test.yml
@@ -29,7 +29,7 @@ jobs:
       run: go build -o strata -v ./cmd
 
     - name: Test
-      run: go test -json -v ./cmd | tee Go_Test_Results.json
+      run: go test -json -v ./pkg/test | tee Go_Test_Results.json
 
     - name: Upload Test Result
       uses: actions/upload-artifact@v4

--- a/.github/workflows/go_unit_test.yml
+++ b/.github/workflows/go_unit_test.yml
@@ -29,7 +29,7 @@ jobs:
       run: go build -o strata -v ./cmd
 
     - name: Test
-      run: go test -json -v ./pkg/test | tee Go_Test_Results.json
+      run: go test -v ./pkg/test | tee Go_Test_Results.txt
 
     - name: Upload Test Result
       uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ADD --chown=strata . /opt/strata
 
 # Install required Go Dependencies
 RUN go install ./cmd
+
 # Build the project
 RUN go build -o strata ./cmd
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ The container can be shut down and removed, while keeping the built image, using
 docker compose down
 ```
 
+### Executing commands in a Running Docker Container
+A shell within the Strata and Postgres containers can be created using the following respective commands:
+```sh
+# Strata
+docker exec -it strata bash
+
+# Postgres
+docker exec -it strata_psql bash
+```
+To run any command within the running docker instance, replace `bash` with the command to execute. Refer to the [Running Tests](#running-tests) section where this is utilized to run the go command within the docker instance. 
+<br>
+To access the 'psql' command within postgresql, ensure the username and database are set to 'strata' (by passing parameters `-U` and `-d` respectively) such as the following command will perform:
+
+```sh
+docker exec -it strata_psql psql -U strata -d strata -f /*.d/1_schema.sql
+```
+
 ## Go Setup
 The following set of commands can be used to install required packages, then build the 'strata' executable in the project root directory. These commands require your terminal's current working directory is the project's root directory.  
 ```sh
@@ -24,5 +41,12 @@ go install ./cmd
 # Build project
 go build -o strata ./cmd
 
-# Result is placed in ./strata
+# Result binary is placed in ./strata
 ``` 
+
+## Running Tests
+To run tests within the docker container, you can use the command below:
+
+```sh
+docker exec -it strata go test -v ./pkg/tests
+```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,10 @@ func main() {
 	server.POST("/logout", api.LogoutHandler(users))
 	server.POST("/auth", api.AuthHandler(users))
 	server.GET("/ping", api.PingHandler)
+	// Query Endpoints
+	server.GET("/query/read/:qid", api.ReadQueryLiteralHandler(db)) // Return the query SQL string
+	server.GET("/query/execute/:qid", api.ExecuteQueryHandler(db)) // Execute a saved query (custom or standard saved queries)
+	server.POST("/query/save", api.SaveQueryHandler(db))
 
 	err = server.Run(":8080")
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"context"
+	"log"
+	"os"
+
 	"github.com/TeamStrata/strata/pkg/api"
 	"github.com/TeamStrata/strata/pkg/database"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
-	"log"
-	"os"
 )
 
 func main() {
@@ -45,9 +46,11 @@ func main() {
 	server.POST("/auth", api.AuthHandler(users))
 	server.GET("/ping", api.PingHandler)
 	// Query Endpoints
-	server.GET("/query/read/:qid", api.ReadQueryLiteralHandler(db)) // Return the query SQL string
-	server.GET("/query/execute/:qid", api.ExecuteQueryHandler(db)) // Execute a saved query (custom or standard saved queries)
+	server.GET("/queries", api.GetQueryList(db))
+	server.GET("/query/:qid", api.ReadQueryLiteralHandler(db))     // Return the query SQL string
+	server.GET("/query/:qid/execute", api.ExecuteQueryHandler(db)) // Execute a saved query (custom or standard saved queries)
 	server.POST("/query/save", api.SaveQueryHandler(db))
+	server.DELETE("/query/:qid", api.DeleteQueryHandler(db))
 
 	err = server.Run(":8080")
 	if err != nil {

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   strata:
+    depends-on: postgres
     build:
       context: ./
       dockerfile: Dockerfile
@@ -14,8 +15,8 @@ services:
   postgres:
     image: postgres:latest
     container_name: strata_psql
-    expose:
-      - 5432
+    ports:
+      - 5432:5432
     volumes:
       - ./database:/docker-entrypoint-initdb.d
       - ./postgres:/var/lib/postgresql/data

--- a/compose.yml
+++ b/compose.yml
@@ -1,17 +1,4 @@
 services:
-  strata:
-    depends-on: postgres
-    build:
-      context: ./
-      dockerfile: Dockerfile
-    container_name: strata
-    image: strata:live
-    ports:
-      - 8080:8080
-    working_dir: /opt/strata
-    volumes:
-      - ./:/opt/strata
-
   postgres:
     image: postgres:latest
     container_name: strata_psql
@@ -24,3 +11,18 @@ services:
       POSTGRES_DB: strata
       POSTGRES_USER: strata
       POSTGRES_PASSWORD: atarts
+      
+  strata:
+    depends_on:
+      postgres:
+        condition: service_started
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: strata
+    image: strata:live
+    ports:
+      - 8080:8080
+    working_dir: /opt/strata
+    volumes:
+      - ./:/opt/strata

--- a/compose.yml
+++ b/compose.yml
@@ -26,3 +26,23 @@ services:
     working_dir: /opt/strata
     volumes:
       - ./:/opt/strata
+
+# This is a dev container for strata, used for live compiling and stuff
+  strata-dev:
+    stdin_open: true
+    tty: true
+    entrypoint: /bin/bash
+    depends_on:
+      postgres:
+        condition: service_started
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: strata-dev
+    image: strata:live
+    ports:
+      - 8081:8080
+    working_dir: /opt/strata
+    volumes:
+      - ./:/opt/strata
+

--- a/database/1_schema.sql
+++ b/database/1_schema.sql
@@ -17,10 +17,49 @@ BEGIN
 		DROP TABLE public.users;
 	END IF;
 
+	-- Table for storing users
 	CREATE TABLE users (
-	user_id SERIAL PRIMARY KEY,
-	user_name TEXT UNIQUE NOT NULL,
-	password_hash TEXT NOT NULL 
+		user_id SERIAL PRIMARY KEY,
+		user_name TEXT UNIQUE NOT NULL,
+		password_hash TEXT NOT NULL
+	);
+
+	-- Table for storing Roles
+	CREATE TABLE IF NOT EXISTS roles (
+		role_id SERIAL PRIMARY KEY,
+		role_name TEXT UNIQUE NOT NULL
+	);
+
+	-- Table for storing Permissions
+	CREATE TABLE IF NOT EXISTS permissions (
+		permission_id SERIAL PRIMARY KEY,
+		permission_name TEXT UNIQUE NOT NULL
+	);
+
+	-- Table for storing custom, or any other queries. 
+	CREATE TABLE IF NOT EXISTS queries (
+		query_id SERIAL PRIMARY KEY,
+		query_string TEXT UNIQUE NOT NULL
+	);
+
+
+	---=== RELATIONS ===---
+	-- Table to store relations between roles and permissions
+	CREATE TABLE IF NOT EXISTS rolePermissions (
+		role_id INTEGER NOT NULL references roles(role_id),
+		permission_id INTEGER NOT NULL references permissions(permission_id)
+	);
+
+	-- Table to store relations between users and roles
+	CREATE TABLE IF NOT EXISTS userRoles (
+		user_id INTEGER NOT NULL references users(user_id),
+		role_id INTEGER NOT NULL references roles(role_id)
+	);
+
+	-- Table to store relations between permissions and queries
+	CREATE TABLE IF NOT EXISTS queryPermissions (
+		query_id INTEGER NOT NULL references queries(query_id),
+		role_id INTEGER NOT NULL references roles(role_id)
 	);
 END
 $do$

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	//	"github.com/TeamStrata/strata/pkg/auth"
+	"encoding/json"
+	"io"
+	"strconv"
+
+	"github.com/TeamStrata/strata/pkg/database"
+	//	"github.com/google/uuid"
+	//	"net/http"
+	//	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Get the list of queries
+func GetQueryList(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		queries, err := d.ListCustomQueries()
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		println(len(queries))
+		data, err2 := json.Marshal(queries)
+		if err2 != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Data(200, "application/json", data)
+	}
+}
+
+// Return the query SQL string
+func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		query_id_str := c.Param("qid")
+
+		query_id, err := strconv.Atoi(query_id_str)
+		if err != nil {
+			c.Data(400, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		query_string, err := d.GetCustomQuery(query_id)
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Data(200, "text/plain", []byte(query_string))
+		c.Done()
+	}
+}
+
+// Execute a saved query (custom or standard saved queries)
+func ExecuteQueryHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {}
+}
+
+func SaveQueryHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		data, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		// Inserting custom query
+		id, err := d.InsertCustomQuery(string(data))
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+
+		c.Done()
+
+	}
+}
+
+func DeleteQueryHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		query_id_str := c.Param("qid")
+
+		query_id, err := strconv.Atoi(query_id_str)
+		if err != nil {
+			c.Data(400, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		q_err := d.DeleteCustomQuery(query_id)
+		if q_err != nil {
+			c.Data(500, "text/plain", []byte(q_err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Status(200)
+		c.Done()
+	}
+}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -140,17 +140,3 @@ func addNewUUID(username string, users map[string]string) string {
 	users[newId] = username
 	return newId
 }
-
- // Return the query SQL string
-func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {}
-}
-
-// Execute a saved query (custom or standard saved queries)
-func ExecuteQueryHandler(d *database.DbManager) gin.HandlerFunc { 
-	return func(c *gin.Context) {}
-}
-
-func SaveQueryHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {}
-}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -140,3 +140,17 @@ func addNewUUID(username string, users map[string]string) string {
 	users[newId] = username
 	return newId
 }
+
+ // Return the query SQL string
+func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {}
+}
+
+// Execute a saved query (custom or standard saved queries)
+func ExecuteQueryHandler(d *database.DbManager) gin.HandlerFunc { 
+	return func(c *gin.Context) {}
+}
+
+func SaveQueryHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {}
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -57,12 +57,13 @@ func (d *DbManager) ConnectToDatabase() error {
 }
 
 // Return a user based on username. Return error if no user found.
-func (d *DbManager) GetUserByUserName(name string) (User, error) {
+func (d *DbManager) GetUserByUserName(name string) (User, error) {	
 	user := User{}
 	var err error
 	if err = d.Connection.Ping(context.Background()); err != nil {
-		return User{}, nil
+		return User{}, err
 	}
+
 
 	query := "SELECT user_name, password_hash FROM users WHERE user_name = $1"
 	err = d.Connection.QueryRow(d.context, query, name).Scan(&user.Name, &user.Password)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -18,6 +18,11 @@ type DbManager struct {
 	context    context.Context
 }
 
+type Query struct {
+	Id      int    `json:"id"`
+	Literal string `json:"literal"`
+}
+
 func NewDbManager(connectionString string, ctx context.Context) (*DbManager, error) {
 	if len(connectionString) == 0 {
 		msg := "error creating new DbManager: empty connection string"
@@ -57,13 +62,12 @@ func (d *DbManager) ConnectToDatabase() error {
 }
 
 // Return a user based on username. Return error if no user found.
-func (d *DbManager) GetUserByUserName(name string) (User, error) {	
+func (d *DbManager) GetUserByUserName(name string) (User, error) {
 	user := User{}
 	var err error
 	if err = d.Connection.Ping(context.Background()); err != nil {
 		return User{}, err
 	}
-
 
 	query := "SELECT user_name, password_hash FROM users WHERE user_name = $1"
 	err = d.Connection.QueryRow(d.context, query, name).Scan(&user.Name, &user.Password)
@@ -80,4 +84,62 @@ func (d *DbManager) InsertUser(username string, password string) error {
 	query := "INSERT INTO users (user_name, password_hash) VALUES ($1, $2) RETURNING user_name, password_hash"
 	err := d.Connection.QueryRow(d.context, query, username, password).Scan(&user.Name, &user.Password)
 	return err
+}
+
+// Insert a custom query into the database
+func (d *DbManager) InsertCustomQuery(query_string string) (int, error) {
+	query_id := 0
+
+	query := "INSERT INTO queries (query_string) VALUES ($1) RETURNING query_id"
+	err := d.Connection.QueryRow(d.context, query, query_string).Scan(&query_id)
+
+	return query_id, err
+}
+
+// Get the custom query string saved as some ID
+func (d *DbManager) GetCustomQuery(query_id int) (string, error) {
+	query_string := ""
+
+	query := "SELECT query_string FROM queries WHERE query_id = $1"
+	err := d.Connection.QueryRow(d.context, query, query_id).Scan(&query_string)
+
+	return query_string, err
+}
+
+// Delete a custom query based on ID
+func (d *DbManager) DeleteCustomQuery(query_id int) error {
+	query := "DELETE FROM queries WHERE query_id = $1"
+	_, err := d.Connection.Exec(d.context, query, query_id)
+
+	return err
+}
+
+// List the available queries
+func (d *DbManager) ListCustomQueries() ([]Query, error) {
+	var list []Query
+	query := "SELECT * FROM queries"
+
+	// Query the databse for all queries
+	rows, err := d.Connection.Query(d.context, query)
+	if err != nil {
+		return nil, err
+	}
+	// Ensure the rows are closed properly
+	defer rows.Close()
+
+	// Iterate through rows
+	for rows.Next() {
+		var query Query
+
+		// Scan the row for the query ID and String Literal
+		err := rows.Scan(&query.Id, &query.Literal)
+		if err != nil {
+			return nil, err
+		}
+
+		list = append(list, query)
+	}
+
+	// Success!
+	return list, nil
 }

--- a/pkg/test/database_test.go
+++ b/pkg/test/database_test.go
@@ -46,6 +46,8 @@ func Test_GetUserByUsername(t *testing.T) {
 	}
 
 	actualUser, err := db.GetUserByUserName(realUser.Name)
+	log.Print(realUser.Name)
+	log.Print(actualUser)
 	if err != nil {
 		t.Fatalf("error getting user by username: %s", err.Error())
 	}


### PR DESCRIPTION
# CRUD For Custom Queries
This pull request implements CRUD functionality for custom queries, saving/loading to/from the database in the 'queries' table. 

Resolves issue/functionality 205 (#26)

## New Working Routes
### `GET /queries`
Get a JSON list of each query. The JSON result is an array of query objects containing two fields: `Id` and `Literal`.

### `POST /query/save`
Save a new query to the database. SQL is expected to be contained as `text/plain` data in the request body. The response body will contain the inserted query ID as an integer upon success.

### `GET /query/:qid`
Results in the server responding with the literal query SQL string in the response body. 

### `DELETE /query/:qid`
Deletes the query from the database. 

## Non Implemented Routes - Planning Only
### `GET /query/:qid/execute`
Not implemented. Planned to execute the query and respond with the JSON result. 

## Docker Compose Change
This update adds a dev container to the docker compose file for use in development. It can be removed in the future and from each release. 

## SQL Schema Update
The SQL schema has been expanded to include the ability to support role-based permissions. This update is backwards-compatible since only new tables were added with no changes to the existing user table. 
