### PR TITLE
fix(#44): Docker container now starting strata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,12 @@ RUN go build -o strata ./cmd
 
 # Install
 USER root
-#RUN cp strata /bin/strata
-RUN ln -sf /opt/strata/strata /bin/strata
+RUN cp strata /bin/strata
 USER strata
 
 
 # Run strata
 # This has to have no '/' characters or it will/can error, so we have to install it above. 
-CMD ["strata"]
+# 
+# If ./strata exists, start that. Otherwise fall back to the version in /bin/strata, installed when the docker image was built. 
+CMD ["bash", "-c", "if [ -f strata ] ; then ./strata ; else strata ; fi"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ docker exec -it strata_psql psql -U strata -d strata -f /*.d/1_schema.sql
 ```
 
 ## Go Setup
-The following set of commands can be used to install required packages, then build the 'strata' executable in the project root directory. These commands require your terminal's current working directory is the project's root directory.  
+The following set of commands can be used to install required packages, then build the 'strata' executable in the project root directory. These commands require your terminal's current working directory is the project's root directory. Once the executable is built, the docker container can be restarted. It will automatically use the new `strata` executable in favour of the fallback stored in the docker container filesystem, at `/bin/strata`. 
+<br>
+These commands can be prefixed by `docker exec -it strata` if you do not have go installed. 
 ```sh
 # Install packages:
 go install ./cmd


### PR DESCRIPTION
This is a fix for issue #44.

Also added the ability to update the application much quicker. If the `./strata` executable exists in the project's root directory, it has highest priority when the docker container starts. The `./strata` executable will execute instead of `/bin/strata`, if `./strata` exists.