### PR TITLE
feat: We can now open the frontend page from the server hosted in docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,11 @@
-# Based on debian:latest
-FROM debian
-WORKDIR /opt/strata
+#################################
+#	STAGE 1 - Backend	#
+#################################
+FROM golang:tip-alpine3.20 AS backend
+WORKDIR /opt/backend
 
-# Expose the port 8080
-# Expose to other containers, not sure if this is needed
-#EXPOSE 8080
-
-# Update and fetch packages
-RUN apt-get -y update && apt-get -y upgrade
-RUN apt-get install -y --no-install-recommends ca-certificates wget
-
-# Download GO
-RUN wget -O /tmp/go.tar.gz https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
-
-# Install GO 
-RUN tar -C /usr/local -xzvf /tmp/go.tar.gz && rm /tmp/go.tar.gz
-RUN ln -s /usr/local/go/bin/* /bin/.
-
-
-# Lower the privilege level in case of attacks
-RUN useradd -m strata
-RUN chown -R strata:strata /opt/strata
-USER strata
-
-# Copy project contents into container
-ADD --chown=strata . /opt/strata 
+# Copy backend sources
+COPY . .
 
 # Install required Go Dependencies
 RUN go install ./cmd
@@ -32,14 +13,38 @@ RUN go install ./cmd
 # Build the project
 RUN go build -o strata ./cmd
 
-# Install
-USER root
-RUN cp strata /bin/strata
-USER strata
+#################################
+#	STAGE 2 - Frontend	#
+#################################
+FROM node:current-slim AS frontend
+WORKDIR /opt/frontend
 
+# Copy UI sources
+COPY ui .
+
+# Install UI lib(s)
+RUN npm install
+
+# Build frontend
+RUN npm run build
+
+
+#################################
+#	STAGE 3 - Production	#
+#################################
+FROM golang:tip-alpine3.20 AS production
+WORKDIR /opt/strata
+
+# Copy in the backend sources
+COPY --from=backend /opt/backend .
+# Also install the strata executable
+COPY --from=backend /opt/backend/strata /bin/strata
+
+# Now copy in the frontend sources on top
+COPY --from=frontend /opt/frontend ui
 
 # Run strata
-# This has to have no '/' characters or it will/can error, so we have to install it above. 
-# 
-# If ./strata exists, start that. Otherwise fall back to the version in /bin/strata, installed when the docker image was built. 
-CMD ["bash", "-c", "if [ -f strata ] ; then ./strata ; else strata ; fi"]
+# This has to have no '/' characters or it will/can error, so we have to install it above.  
+#
+# If ./strata exists, start that. Otherwise fall back to the version in /bin/strata, installed when the docker image was built.
+CMD ["sh", "-c", "if [ -f strata ] ; then ./strata ; else strata ; fi"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,12 +42,22 @@ func main() {
 	// Initialize map for users and uuids
 	users := make(map[string]string)
 
-	// Endpoints
+	// API Endpoints
 	server.POST("/login", api.LoginHandler(db, users))
 	server.POST("/signup", api.SignUpHandler(db, users))
 	server.POST("/logout", api.LogoutHandler(users))
 	server.POST("/auth", api.AuthHandler(users))
 	server.GET("/ping", api.PingHandler)
+
+	// Frontend
+	server.Static("/assets", "ui/dist/assets")
+	server.StaticFile("/", "ui/dist/index.html")
+	server.StaticFile("/favicon.ico", "ui/dist/favicon.ico")
+
+	// Account / Roles
+
+	// Dashboard Components
+
 	// Query Endpoints
 	server.GET("/queries", api.GetQueryList(db))
 	server.GET("/query/:qid", api.ReadQueryLiteralHandler(db))     // Return the query SQL string

--- a/compose.yml
+++ b/compose.yml
@@ -35,8 +35,7 @@ services:
     ports:
       - 8080:8080
     working_dir: /opt/strata
-    volumes:
-      - ./:/opt/strata
+#   The non development container does not need a shared volume for strata itself.
 
 # This is a dev container for strata, used for live compiling and stuff
 #  strata-dev:


### PR DESCRIPTION
I also redid the Dockerfile so that it keeps the image small, and keeps build time low, while still building the frontend with npm, and the backend with go. 

Sources are no longer in a shared volume with the default 'strata' container, since if they are, the sources built from Dockerfile are overwritten. To rebuild, run `docker compose up --build`. Any changes to the frontend or backend will be considered and recompiled. 