### PR TITLE
fix: Git unit tests for go are reporting as passing even if they fail. 

### DIFF
--- a/.github/workflows/go_unit_test.yml
+++ b/.github/workflows/go_unit_test.yml
@@ -29,10 +29,6 @@ jobs:
       run: go build -o strata -v ./cmd
 
     - name: Test
-      run: go test -v ./pkg/test | tee Go_Test_Results.txt
+      run: go test -v ./pkg/test
 
-    - name: Upload Test Result
-      uses: actions/upload-artifact@v4
-      with:
-        name: Go_Test_Results
-        path: Go_Test_Results.json
+


### PR DESCRIPTION
Go Unit Test action in github is showing as passing even if the test fails. This was due to me piping the results into `tee`, which was masking the return value of go, hiding the failure. 