### PR TITLE
fix(#78): Fix for the shared .env file between Docker and local

### DIFF
--- a/.env.Docker
+++ b/.env.Docker
@@ -1,0 +1,7 @@
+CONNECTION_STRING: "postgresql://strata:atarts@strata_psql:5432/strata"
+DB_HOSTNAME=strata_psql
+DB_USERNAME=strata
+DB_PASSWORD=atarts
+DB_DATABASE=strata
+DB_PORT=5432
+

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ postgres/*
 
 # Ollama stuff
 ollama/*
+
+# Local .env
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /opt/backend
 # Copy backend sources
 COPY . .
 
+# Overwrite the .env file with the Docker-specific .env file
+COPY .env.Docker .env
+
 # Install required Go Dependencies
 RUN go install ./cmd
 


### PR DESCRIPTION
Now, the .env.Docker file is used for the docker container, and the .env file is used otherwise.