### PR TITLE
Separate Customer Data-Only Database - #124

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,11 +79,13 @@ func main() {
 		protected.GET("/chart/:cid", api.GetChartHandler(db))
 		protected.POST("/chart", api.CreateChartHandler(db))
 		protected.DELETE("/chart/:cid", api.DeleteChartHandler(db))
+		protected.PATCH("/chart/:cid", api.UpdateChartHandler(db))
 		/// Chart Series
 		protected.GET("/chart/:cid/series", api.GetChartSeriesListHandler(db))
 		protected.GET("/chart/:cid/series/:sid", api.GetChartSingleSeriesHandler(db))
 		protected.POST("/chart/:cid/series", api.AddChartSeriesHandler(db))
 		protected.DELETE("/chart/:cid/series/:sid", api.DeleteChartSingleSeriesHandler(db))
+		protected.PATCH("/chart/:cid/series/:sid", api.UpdateChartSeriesHandler(db))
 		protected.DELETE("/chart/:cid/series", api.DeleteAllChartSeriesHandler(db))
 		/// Dashboard itself
 		protected.GET("/dashboards", api.GetDashboardListHandler(db))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,13 @@ func main() {
 		log.Fatalf("error initializing DB manager: %s", err.Error())
 	}
 
+	// Create the client database which will be used for custom queries
+	cdb_str, cerr := db.GetSetting("cdb")
+	cdb, cerr := database.NewDbManager(cdb_str, context.Background())
+	if cerr != nil {
+		log.Printf("error initializing client DB manager: %s", cerr.Error())
+	}
+
 	// Initialize map for active users and uuids
 	activeUsers := make(map[string]string)
 
@@ -99,7 +106,7 @@ func main() {
 		// Query Endpoints
 		protected.GET("/queries", api.GetQueryList(db))
 		protected.GET("/query/:qid", api.ReadQueryLiteralHandler(db))     // Return the query SQL string
-		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db)) // Execute a saved query (custom or standard saved queries)
+		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db, cdb)) // Execute a saved query (custom or standard saved queries)
 		protected.POST("/query/:qid", api.SaveQueryHandler(db))
 		protected.DELETE("/query/:qid", api.DeleteQueryHandler(db))
 
@@ -108,6 +115,8 @@ func main() {
 
 		// Misc Endpoints
 		protected.GET("/ping", api.PingHandler)
+		protected.GET("/settings/:key", api.GetSettingHandler(db))
+		protected.POST("/settings/:key", api.UpdateSettingHandler(db))
 	}
 
 	err = server.Run(":8080")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,8 +115,9 @@ func main() {
 
 		// Misc Endpoints
 		protected.GET("/ping", api.PingHandler)
+		protected.GET("/settings", api.GetAllSettingsHandler(db))
 		protected.GET("/settings/:key", api.GetSettingHandler(db))
-		protected.POST("/settings/:key", api.UpdateSettingHandler(db, &cdb))
+		protected.PATCH("/settings/:key", api.UpdateSettingHandler(db, &cdb))
 	}
 
 	err = server.Run(":8080")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -106,7 +106,7 @@ func main() {
 		// Query Endpoints
 		protected.GET("/queries", api.GetQueryList(db))
 		protected.GET("/query/:qid", api.ReadQueryLiteralHandler(db))     // Return the query SQL string
-		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db, cdb)) // Execute a saved query (custom or standard saved queries)
+		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db, &cdb)) // Execute a saved query (custom or standard saved queries)
 		protected.POST("/query/:qid", api.SaveQueryHandler(db))
 		protected.DELETE("/query/:qid", api.DeleteQueryHandler(db))
 
@@ -116,7 +116,7 @@ func main() {
 		// Misc Endpoints
 		protected.GET("/ping", api.PingHandler)
 		protected.GET("/settings/:key", api.GetSettingHandler(db))
-		protected.POST("/settings/:key", api.UpdateSettingHandler(db))
+		protected.POST("/settings/:key", api.UpdateSettingHandler(db, &cdb))
 	}
 
 	err = server.Run(":8080")

--- a/database/1_schema.sql
+++ b/database/1_schema.sql
@@ -121,8 +121,8 @@ BEGIN
 
 	-- Table to store settings such as the client database connection string
 	CREATE TABLE IF NOT EXISTS settings (
-		setting_key TEXT UNIQUE NOT NULL,
-		setting_value TEXT NOT NULL
+		skey TEXT UNIQUE NOT NULL,
+		svalue TEXT NOT NULL
 	);
 END
 $do$

--- a/database/1_schema.sql
+++ b/database/1_schema.sql
@@ -118,5 +118,11 @@ BEGIN
 		query_id INTEGER NOT NULL references queries(query_id) ON DELETE CASCADE,
 		role_id INTEGER NOT NULL references roles(role_id) ON DELETE CASCADE
 	);
+
+	-- Table to store settings such as the client database connection string
+	CREATE TABLE IF NOT EXISTS settings (
+		setting_key TEXT UNIQUE NOT NULL,
+		setting_value TEXT NOT NULL
+	);
 END
 $do$

--- a/database/2_data.sql
+++ b/database/2_data.sql
@@ -42,6 +42,10 @@ BEGIN
 		INSERT INTO userroles (user_id, role_id)
 		VALUES (admin_user_id, admin_role_id)
 		ON CONFLICT DO NOTHING;
+
+		INSERT INTO settings (skey, svalue)
+		VALUES ('cdb', 'postgresql://strata:atarts@strata_psql:5432/strata')
+		ON CONFLICT DO NOTHING;
 	END IF;
 END
 $do$

--- a/pkg/api/dashcharts.go
+++ b/pkg/api/dashcharts.go
@@ -104,6 +104,35 @@ func DeleteChartHandler(d *database.DbManager) gin.HandlerFunc {
 	}
 }
 
+func UpdateChartHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chart_id_str := c.Param("cid")
+		chart_id, err := strconv.Atoi(chart_id_str)
+		if err != nil {
+			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
+			c.Done()
+			return
+		}
+
+		var chart database.Chart
+		if err := c.ShouldBindJSON(&chart); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		chart.Id = chart_id
+
+		err = d.UpdateChart(chart)
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Status(200)
+		c.Done()
+	}
+}
+
 // / Chart Series
 func GetChartSeriesListHandler(d *database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -203,6 +232,35 @@ func DeleteChartSingleSeriesHandler(d *database.DbManager) gin.HandlerFunc {
 		}
 
 		err = d.DeleteChartSeries(series_id)
+		if err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+
+		c.Status(200)
+		c.Done()
+	}
+}
+
+func UpdateChartSeriesHandler(d *database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		series_id_str := c.Param("sid")
+		series_id, err := strconv.Atoi(series_id_str)
+		if err != nil {
+			c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
+			c.Done()
+			return
+		}
+
+		var series database.ChartSeries
+		if err := c.ShouldBindJSON(&series); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		series.Id = series_id
+
+		err = d.UpdateChartSeries(series)
 		if err != nil {
 			c.Data(500, "text/plain", []byte(err.Error()))
 			c.Done()

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -78,7 +78,7 @@ func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 500 {string} string "Internal Server Error"
 // @Param qid query string type "Query name or ID"
 // @Router /query/{qid}/execute [get]
-func ExecuteQueryHandler(d *database.DbManager) gin.HandlerFunc {
+func ExecuteQueryHandler(d *database.DbManager, cd *database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		query_id_str := c.Param("qid")
 
@@ -90,7 +90,7 @@ func ExecuteQueryHandler(d *database.DbManager) gin.HandlerFunc {
 		}
 
 		// Perform the custom query
-		rows, qerr := d.ExecuteCustomQuery(query_string)
+		rows, qerr := cd.ExecuteCustomQuery(query_string)
 		if qerr != nil {
 			c.Data(500, "text/plain", []byte(qerr.Error()))
 			c.Done()

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
+	"log"
 
 	"github.com/TeamStrata/strata/pkg/database"
 	"github.com/gin-gonic/gin"
@@ -78,9 +79,11 @@ func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 500 {string} string "Internal Server Error"
 // @Param qid query string type "Query name or ID"
 // @Router /query/{qid}/execute [get]
-func ExecuteQueryHandler(d *database.DbManager, cd *database.DbManager) gin.HandlerFunc {
+func ExecuteQueryHandler(d *database.DbManager, cd **database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		query_id_str := c.Param("qid")
+
+		log.Printf("Ptr at execute: '%p'\n", *cd)
 
 		_, query_string, serr := d.GetCustomQuery(query_id_str)
 		if serr != nil {
@@ -90,7 +93,7 @@ func ExecuteQueryHandler(d *database.DbManager, cd *database.DbManager) gin.Hand
 		}
 
 		// Perform the custom query
-		rows, qerr := cd.ExecuteCustomQuery(query_string)
+		rows, qerr := (*cd).ExecuteCustomQuery(query_string)
 		if qerr != nil {
 			c.Data(500, "text/plain", []byte(qerr.Error()))
 			c.Done()

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"context"
+	"log"
 
 	"github.com/TeamStrata/strata/pkg/auth"
 	"github.com/TeamStrata/strata/pkg/database"
@@ -509,7 +511,7 @@ func addNewUUID(username string, users map[string]string) string {
 
 func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		key := c.Param("qid")
+		key := c.Param("key")
 
 		settings, err := d.GetSetting(key)
 		if err != nil {
@@ -522,9 +524,9 @@ func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {
 	}
 }
 
-func UpdateSettingHandler(d* database.DbManager) gin.HandlerFunc {
+func UpdateSettingHandler(d* database.DbManager, cdb** database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		key := c.Param("qid")
+		key := c.Param("key")
 
 		bodyBytes, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -539,6 +541,23 @@ func UpdateSettingHandler(d* database.DbManager) gin.HandlerFunc {
 			c.String(http.StatusInternalServerError, errMsg)
 			return
 		}
+
+		log.Printf("Before: '%p'\n", *cdb)
+
+		// Disconnect from the client database, then reconnect to this new database
+		if *cdb != nil {
+			(*cdb).Connection.Close()
+			*cdb = nil
+		}
+
+		// Attempt to connect to new database so you don't have to restart the server
+		*cdb, err = database.NewDbManager(string(bodyBytes), context.Background())
+		if err != nil {
+			errMsg := fmt.Sprintf("Unable to connect to new database: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+		log.Printf("After: '%p'\n", *cdb)
 
 		c.Status(http.StatusOK)
 	}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -504,4 +505,41 @@ func addNewUUID(username string, users map[string]string) string {
 
 	users[newId] = username
 	return newId
+}
+
+func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := c.Param("qid")
+
+		settings, err := d.GetSetting(key)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to get settings: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		c.JSON(http.StatusOK, settings)
+	}
+}
+
+func UpdateSettingHandler(d* database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := c.Param("qid")
+
+		bodyBytes, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to read request body: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		err = d.SetSetting(key, string(bodyBytes))
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to update settings: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		c.Status(http.StatusOK)
+	}
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/gin-gonic/gin"
+	"encoding/json"
 )
 
 const uuidTag = "uuid"
@@ -507,6 +508,28 @@ func addNewUUID(username string, users map[string]string) string {
 
 	users[newId] = username
 	return newId
+}
+
+func GetAllSettingsHandler(d* database.DbManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		settings, err := d.ExecuteCustomQuery("SELECT skey, svalue FROM settings;")
+		if err != nil {
+			errMsg := fmt.Sprintf("Unable to get all settings: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		// Convert the resulting object to JSON
+		data, jerr := json.Marshal(settings)
+		if jerr != nil {
+			c.Data(500, "text/plain", []byte(jerr.Error()))
+			c.Done()
+			return
+		}
+
+		c.Data(200, "application/json", data)
+		c.Done()
+	}
 }
 
 func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -63,6 +63,11 @@ type Query struct {
 	Literal string `json:"literal"`
 }
 
+type Settings struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 func NewDbManager(connectionString string, ctx context.Context) (*DbManager, error) {
 	if len(connectionString) == 0 {
 		msg := "error creating new DbManager: empty connection string"
@@ -558,4 +563,29 @@ func (d *DbManager) ExecuteCustomQuery(query string) ([]map[string]string, error
 
 	// Success
 	return retRows, nil
+}
+
+// Get key-value pair from settings table in database
+func (d *DbManager) GetSetting(key string) (string, error) {
+	query := "SELECT value FROM settings WHERE key = $1;"
+	var value string
+
+	err := d.Connection.QueryRow(d.context, query, key).Scan(&value)
+	if err != nil {
+		return "", fmt.Errorf("error getting setting '%s': %w", key, err)
+	}
+
+	return value, nil
+}
+
+// Set or update a key-value pair in the settings table in the database
+func (d *DbManager) SetSetting(key string, value string) error {
+	query := "INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2;"
+
+	_, err := d.Connection.Exec(d.context, query, key, value)
+	if err != nil {
+		return fmt.Errorf("error setting key '%s' to value '%s': %w", key, value, err)
+	}
+
+	return nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -517,6 +517,10 @@ func (d *DbManager) ListCustomQueries() ([]Query, error) {
 }
 
 func (d *DbManager) ExecuteCustomQuery(query string) ([]map[string]string, error) {
+	if d == nil {
+		return nil, errors.New("This service has not been connected to a data-only database.\nUse POST /settings/cdb to set the postgres connection string.")
+	}
+
 	var retRows []map[string]string
 
 	// Get Rows
@@ -567,7 +571,7 @@ func (d *DbManager) ExecuteCustomQuery(query string) ([]map[string]string, error
 
 // Get key-value pair from settings table in database
 func (d *DbManager) GetSetting(key string) (string, error) {
-	query := "SELECT value FROM settings WHERE key = $1;"
+	query := "SELECT svalue FROM settings WHERE skey = $1;"
 	var value string
 
 	err := d.Connection.QueryRow(d.context, query, key).Scan(&value)
@@ -580,7 +584,7 @@ func (d *DbManager) GetSetting(key string) (string, error) {
 
 // Set or update a key-value pair in the settings table in the database
 func (d *DbManager) SetSetting(key string, value string) error {
-	query := "INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2;"
+	query := "INSERT INTO settings (skey, svalue) VALUES ($1, $2) ON CONFLICT (skey) DO UPDATE SET svalue = $2;"
 
 	_, err := d.Connection.Exec(d.context, query, key, value)
 	if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -584,7 +584,7 @@ func (d *DbManager) GetSetting(key string) (string, error) {
 
 // Set or update a key-value pair in the settings table in the database
 func (d *DbManager) SetSetting(key string, value string) error {
-	query := "INSERT INTO settings (skey, svalue) VALUES ($1, $2) ON CONFLICT (skey) DO UPDATE SET svalue = $2;"
+	query := "UPDATE settings SET svalue = $2 WHERE skey = $1;"
 
 	_, err := d.Connection.Exec(d.context, query, key, value)
 	if err != nil {

--- a/pkg/database/db_dashboard.go
+++ b/pkg/database/db_dashboard.go
@@ -96,6 +96,12 @@ func (d *DbManager) DeleteChart(chart_id int) error {
 	return err
 }
 
+func (d *DbManager) UpdateChart(chart Chart) error {
+    query := "UPDATE chart SET chart_title = $1, chart_type = $2 WHERE chart_id = $3;"
+    _, err := d.Connection.Exec(d.context, query, chart.Title, chart.Type, chart.Id)
+    return err
+}
+
 func (d *DbManager) ListChartSeries(chart_id int) ([]ChartSeries, error) {
     var list []ChartSeries
     query := "SELECT series_id, chart_id, query_id, x_column, y_column FROM chartSeries WHERE chart_id = $1;"
@@ -139,6 +145,12 @@ func (d *DbManager) DeleteChartSeries(series_id int) error {
 func (d *DbManager) DeleteAllChartSeries(chart_id int) error {
     query := "DELETE FROM chartSeries WHERE chart_id = $1;"
     _, err := d.Connection.Exec(d.context, query, chart_id)
+    return err
+}
+
+func (d* DbManager) UpdateChartSeries(series ChartSeries) error {
+    query := "UPDATE chartSeries SET chart_id = $1, query_id = $2, x_column = $3, y_column = $4 WHERE series_id = $5;"
+    _, err := d.Connection.Exec(d.context, query, series.ChartID, series.QueryID, series.XCol, series.YCol, series.Id)
     return err
 }
 

--- a/ui/src/components/AdminSettings.vue
+++ b/ui/src/components/AdminSettings.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { ref } from 'vue';
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardFooter, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import CardDotted from './CardDotted.vue';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { apiFetch } from '@/api/request';
+import Toast, { ToastTypes } from './Toast.vue';
+
+const settings = ref([]);
+
+const toastRef = ref(null);
+const editModal = ref(false);
+const createModal = ref(false);
+const deleteModal = ref(false);
+
+
+
+// Show the edit role dialog
+function showEdit(id) {
+    console.log(id)
+    const settingToEdit = settings.value.find(item => { return item.id == id });
+    tempRole.value = JSON.parse(JSON.stringify(settingToEdit));
+    originalRole = JSON.parse(JSON.stringify(settingToEdit));
+    editModal.value = true;
+}
+
+// Send PATCH request to backend API
+function submitEdit(key) {
+    let value = document.getElementById(`setting-${key}`).value
+    console.log(value);
+ 
+    apiFetch(`/settings/${key}`, "PATCH", value)
+        .then((response) => {
+            if (!response.ok) {
+                toastRef.value?.showToast(
+                    "There was an issue updating the role",
+                    ToastTypes.FAIL,
+                );
+                throw new Error("Unable to update role")
+            } else {
+                editModal.value = false;
+                toastRef.value?.showToast(
+                    "Role updated successfully",
+                    ToastTypes.SUCCESS,
+                );
+                loadSettings();
+            }
+        })
+        .catch((error) => {
+            console.error("Error:", error);
+        });
+}
+
+// Fetch roles from backend API
+function loadSettings() {
+    apiFetch("/settings")
+        .then(async (response) => {
+            
+            if (!response.ok) {
+                toastRef.value?.showToast(
+                    "There was an issue getting all settings",
+                    ToastTypes.FAIL,
+                );
+                throw new Error("Failed to fetch all settings");
+            }
+
+            settings.value = await response.json();
+            console.log(settings.value)
+        })
+        .catch((error) => {
+            console.error(error);
+        });
+}
+
+loadSettings();
+</script>
+
+<template>
+    <Toast ref="toastRef" />
+
+
+    <!-- list header -->
+    <div class="flex flex-row justify-between items-center mb-6">
+        <h1 class="text-2xl font-semibold text-gray-800">Settings</h1>
+        <div class="flex flex-row pb-2 items-center space-x-3">
+            <p class="text-gray-600">{{ settings.length }} Setting(s)</p>
+            <input placeholder="Search"
+                class="p-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-64"
+                type="text">
+        </div>
+    </div>
+
+    <ul class="grid grid-cols-1 lg:grid-cols-1 auto-rows-fr gap-4 items-start">
+        <li v-for="s in settings" :key="s.skey" class="h-full">
+            <Card class="h-full">
+                <CardHeader class="flex items-center justify-between">
+                    <CardTitle class="text-lg">{{ s.skey }}</CardTitle>
+                    <Input :id="`setting-${s.skey}`" :defaultValue="s.svalue"></Input>
+                </CardHeader>
+                <CardFooter class="flex justify-between gap-x-4">
+                    <Button class="flex-1" variant="outline" @click="submitEdit(s.skey)">Push Change</Button>
+                </CardFooter>
+            </Card>
+        </li>
+    </ul> 
+</template>

--- a/ui/src/components/Navbar.vue
+++ b/ui/src/components/Navbar.vue
@@ -64,7 +64,7 @@ const user = useUserStore()
                         </SidebarMenuItem>
                         <SidebarMenuItem>
                             <SidebarMenuButton asChild>
-                                <RouterLink to="/admin/roles">
+                                <RouterLink to="/admin/settings">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
                                         <g fill="none" stroke="currentColor" stroke-linecap="round"
                                             stroke-linejoin="round" stroke-width="2">

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -51,7 +51,7 @@ const router = createRouter({
               path: 'users',
               meta: {
                 title: 'Members',
-                description: 'Manage your organizations members.',
+                description: 'Manage your organization\'s members.',
                 configurable: false,
               },
               component: () => import('../components/AdminUsers.vue')
@@ -60,10 +60,19 @@ const router = createRouter({
               path: 'roles',
               meta: {
                 title: 'Roles',
-                description: 'Manage your organizations roles.',
+                description: 'Manage your organization\'s roles.',
                 configurable: false,
               },
               component: () => import('../components/AdminRoles.vue')
+            },
+            {
+              path: 'settings',
+              meta: {
+                title: 'Settings',
+                description: 'Manage your platform settings.',
+                configurable: false,
+              },
+              component: () => import('../components/AdminSettings.vue')
             }
           ]
         },


### PR DESCRIPTION
Adds the `settings` table to the database which stores key-value pairs to be saved and loaded by the customer. 

This PR adds the ability for /api/query/run to be performed on a separate database, which has its connection string specified by sending a `POST` to `/api/settings/cdb`, or reading it via `GET`  `/api/settings/cdb`. 

The Settings UI page has had content implemented, which allows changing the client database connection string. When the string is changed, the server attempts to re-connect to the client DB. To reconnect, simply attempt to send another edit request with the same value. 

By default, the connection string used within the docker container is inserted into the database. This can be changed for local development simply by going to the Settings page, and changing the connection string used to match what is intended. 

Expected default view in the settings page:
![image](https://github.com/user-attachments/assets/b34d1f47-15aa-4dec-a4ac-8f0c0eed960f)