### PR TITLE
Add admin authentication

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 	// Map for active users and uuids
 	// key: uuid
 	// value: username
-	activeUsers := make(map[string]string)
+	activeUsers := make(map[string]api.UserSessionData)
 
 	// Frontend
 	server.Static("/assets", "ui/dist/assets")
@@ -62,29 +62,8 @@ func main() {
 	protected := server.Group("/api")
 	{
 		protected.Use(api.AuthHandler(activeUsers))
-		protected.POST("/signup", api.SignUpHandler(db, activeUsers))
 		protected.POST("/logout", api.LogoutHandler(activeUsers))
 		protected.POST("/auth", api.AuthHandler(activeUsers))
-
-		// Users
-		protected.GET("/users", api.GetUsersHandler(db))
-		protected.GET("/user/:uid", api.GetUserHandler(db))
-		protected.DELETE("/user/:uname", api.DeleteUserHandler(db, activeUsers))
-		protected.PATCH("/user/:uid", api.UpdateUserHandler(db))
-
-		// User roles
-		protected.DELETE("/user/:uname/role/:rname", api.DeleteUserRoleHandler(db))
-		protected.POST("/user/:uname/role/:rname", api.AddUserRoleHandler(db))
-
-		// Roles
-		protected.GET("/roles", api.GetRolesHandler(db))
-		protected.POST("/role", api.AddRoleHandler(db))
-		protected.PATCH("/role/:rid", api.UpdateRoleHandler(db))
-		protected.DELETE("/role/:rid", api.DeleteRoleHandler(db))
-
-		// Permissions
-		protected.GET("/permissions", api.GetPermissionsHandler(db))
-		protected.GET("/permissions/:scope", api.GetScopedPermissionsHandler(db))
 
 		// Dashboard Components
 		/// Charts
@@ -111,7 +90,7 @@ func main() {
 
 		// Query Endpoints
 		protected.GET("/queries", api.GetQueryList(db))
-		protected.GET("/query/:qid", api.ReadQueryLiteralHandler(db))     // Return the query SQL string
+		protected.GET("/query/:qid", api.ReadQueryLiteralHandler(db))           // Return the query SQL string
 		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db, &cdb)) // Execute a saved query (custom or standard saved queries)
 		protected.POST("/query/:qid", api.SaveQueryHandler(db))
 		protected.DELETE("/query/:qid", api.DeleteQueryHandler(db))
@@ -121,9 +100,36 @@ func main() {
 
 		// Misc Endpoints
 		protected.GET("/ping", api.PingHandler)
-		protected.GET("/settings", api.GetAllSettingsHandler(db))
-		protected.GET("/settings/:key", api.GetSettingHandler(db))
-		protected.PATCH("/settings/:key", api.UpdateSettingHandler(db, &cdb))
+
+		admin := protected.Group("/admin")
+		{
+			// Account creation
+			admin.POST("/signup", api.SignUpHandler(db, activeUsers))
+
+			// Users
+			admin.GET("/users", api.GetUsersHandler(db))
+			admin.GET("/user/:uid", api.GetUserHandler(db))
+			admin.DELETE("/user/:uname", api.DeleteUserHandler(db, activeUsers))
+			admin.PATCH("/user/:uid", api.UpdateUserHandler(db))
+
+			// User roles
+			admin.DELETE("/user/:uname/role/:rname", api.DeleteUserRoleHandler(db))
+			admin.POST("/user/:uname/role/:rname", api.AddUserRoleHandler(db))
+
+			// Roles
+			admin.GET("/roles", api.GetRolesHandler(db))
+			admin.POST("/role", api.AddRoleHandler(db))
+			admin.PATCH("/role/:rid", api.UpdateRoleHandler(db))
+			admin.DELETE("/role/:rid", api.DeleteRoleHandler(db))
+
+			// Permissions
+			admin.Use(api.AuthHandler(activeUsers))
+			admin.GET("/permissions", api.GetPermissionsHandler(db))
+			admin.GET("/permissions/:scope", api.GetScopedPermissionsHandler(db))
+			admin.GET("/settings", api.GetAllSettingsHandler(db))
+			admin.GET("/settings/:key", api.GetSettingHandler(db))
+			admin.PATCH("/settings/:key", api.UpdateSettingHandler(db, &cdb))
+		}
 	}
 
 	err = server.Run(":8080")

--- a/database/1_schema.sql
+++ b/database/1_schema.sql
@@ -12,22 +12,9 @@ BEGIN
 		SELECT 1
 		FROM information_schema.tables
 		WHERE table_schema = 'public'
-		AND table_name = 'users'
 	) THEN
-		DROP TABLE IF EXISTS public.dashboardRolePermissions CASCADE;
-		DROP TABLE IF EXISTS public.rolePermissions CASCADE;
-		DROP TABLE IF EXISTS public.userRoles CASCADE;
-		DROP TABLE IF EXISTS public.queryPermissions CASCADE;
-		DROP TABLE IF EXISTS public.dashboardGraphs CASCADE;
-		DROP TABLE IF EXISTS public.chartSeries CASCADE;
-		DROP TABLE IF EXISTS public.chart CASCADE;
-		DROP TABLE IF EXISTS public.dashboard CASCADE;
-		DROP TABLE IF EXISTS public.queries CASCADE;
-		DROP TABLE IF EXISTS public.permissions CASCADE;
-		DROP TABLE IF EXISTS public.roles CASCADE;
-		DROP TABLE IF EXISTS public.users CASCADE;
-		DROP TYPE IF EXISTS scope CASCADE;
-		DROP TYPE IF EXISTS CHART_TYPE CASCADE;
+		DROP SCHEMA public CASCADE;
+		CREATE SCHEMA public;
 	END IF;
 
 	DO $$ BEGIN

--- a/database/2_data.sql
+++ b/database/2_data.sql
@@ -66,7 +66,12 @@ BEGIN
 
 		-- Assign the 'admin' role the 'admin_privileges` permission.
 		INSERT INTO rolePermissions (role_id, permission_id)
-		VALUES (2, 1);
+		VALUES
+			(2, 1),
+			(2, 2),
+			(2, 3),
+			(2, 4),
+			(2, 5);
 	END IF;
 END
 $do$

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -75,7 +75,12 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "isAdmin": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     },
                     "400": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -64,7 +64,12 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "isAdmin": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     },
                     "400": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -112,7 +112,10 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
+            properties:
+              isAdmin:
+                type: boolean
+            type: object
         "400":
           description: Bad Request
           schema:

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1,20 +1,26 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
-	"context"
-	"log"
 
 	"github.com/TeamStrata/strata/pkg/auth"
 	"github.com/TeamStrata/strata/pkg/database"
 	"github.com/google/uuid"
 
-	"github.com/gin-gonic/gin"
 	"encoding/json"
+
+	"github.com/gin-gonic/gin"
 )
+
+type UserSessionData struct {
+	Name    string
+	IsAdmin bool
+}
 
 const uuidTag = "uuid"
 
@@ -31,7 +37,7 @@ const uuidTag = "uuid"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /login [post]
-func LoginHandler(d *database.DbManager, activeUsers map[string]string) gin.HandlerFunc {
+func LoginHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		login := database.User{}
 		err := c.ShouldBindJSON(&login)
@@ -52,7 +58,14 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]string) gin.Hand
 			return
 		}
 
-		newId := addNewUUID(user.Name, activeUsers)
+		isAdmin, err := d.IsUserAdmin(user)
+		if err != nil {
+			errMsg := fmt.Sprintf("internal server error: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		newId := addNewUUID(user.Name, isAdmin, activeUsers)
 		c.SetCookie(
 			uuidTag,
 			newId,
@@ -62,7 +75,11 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]string) gin.Hand
 			false,
 			true,
 		)
-		c.Status(http.StatusOK)
+
+		body := map[string]any{
+			"isAdmin": isAdmin,
+		}
+		c.JSON(http.StatusOK, body)
 	}
 }
 
@@ -76,7 +93,7 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]string) gin.Hand
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 204 {string} string "No Content"
 // @Router /logout [post]
-func LogoutHandler(activeUsers map[string]string) gin.HandlerFunc {
+func LogoutHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id, err := c.Cookie(uuidTag)
 		if err != nil {
@@ -105,7 +122,7 @@ func LogoutHandler(activeUsers map[string]string) gin.HandlerFunc {
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 204 {string} string "No Content"
 // @Router /auth [get]
-func AuthHandler(activeUsers map[string]string) gin.HandlerFunc {
+func AuthHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uuid, err := c.Cookie(uuidTag)
 		if err != nil {
@@ -141,17 +158,21 @@ func PingHandler(c *gin.Context) {
 }
 
 // Generate UUID if user does not already have one
-func addNewUUID(username string, users map[string]string) string {
+func addNewUUID(username string, isAdmin bool, users map[string]UserSessionData) string {
 	newId := uuid.NewString()
 	for _, ok := users[newId]; ok; {
 		newId = uuid.NewString()
 	}
 
-	users[newId] = username
+	users[newId] = UserSessionData{
+		Name:    username,
+		IsAdmin: isAdmin,
+	}
+
 	return newId
 }
 
-func GetAllSettingsHandler(d* database.DbManager) gin.HandlerFunc {
+func GetAllSettingsHandler(d *database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		settings, err := d.ExecuteCustomQuery("SELECT skey, svalue FROM settings;")
 		if err != nil {
@@ -173,7 +194,7 @@ func GetAllSettingsHandler(d* database.DbManager) gin.HandlerFunc {
 	}
 }
 
-func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {
+func GetSettingHandler(d *database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		key := c.Param("key")
 
@@ -188,7 +209,7 @@ func GetSettingHandler(d* database.DbManager) gin.HandlerFunc {
 	}
 }
 
-func UpdateSettingHandler(d* database.DbManager, cdb** database.DbManager) gin.HandlerFunc {
+func UpdateSettingHandler(d *database.DbManager, cdb **database.DbManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		key := c.Param("key")
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -32,7 +32,7 @@ const uuidTag = "uuid"
 // @Accept json
 // @Produce json
 // @Param login body database.User true "User credentials"
-// @Success 200 {string} string "OK"
+// @Success 200 {object} object{isAdmin=bool} "OK"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
@@ -76,7 +76,7 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]UserSessionData)
 			true,
 		)
 
-		body := map[string]any{
+		body := map[string]bool{
 			"isAdmin": isAdmin,
 		}
 		c.JSON(http.StatusOK, body)

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -23,7 +23,7 @@ import (
 // @Failure 400 {string} string "Bad Request - Invalid JSON format"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /signup [post]
-func SignUpHandler(d *database.DbManager, activeUsers map[string]string) gin.HandlerFunc {
+func SignUpHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		user := database.User{}
 		err := c.ShouldBindJSON(&user)
@@ -46,7 +46,14 @@ func SignUpHandler(d *database.DbManager, activeUsers map[string]string) gin.Han
 			return
 		}
 
-		newId := addNewUUID(user.Name, activeUsers)
+		isAdmin, err := d.IsUserAdmin(user)
+		if err != nil {
+			errMsg := fmt.Sprintf("internal server error: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		newId := addNewUUID(user.Name, isAdmin, activeUsers)
 		c.SetCookie(
 			uuidTag,
 			newId,
@@ -123,12 +130,12 @@ func GetUserHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {string} string "User deleted successfully"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uname} [delete]
-func DeleteUserHandler(d *database.DbManager, activeUsers map[string]string) gin.HandlerFunc {
+func DeleteUserHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("uname")
 
-		for id, tmpName := range activeUsers {
-			if tmpName == name {
+		for id, user := range activeUsers {
+			if user.Name == name {
 				delete(activeUsers, id)
 				break
 			}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"slices"
@@ -242,6 +243,31 @@ func (d *DbManager) DeleteUser(username string) error {
 		WHERE user_name = $1`
 	_, err := d.Connection.Query(d.context, query, username)
 	return err
+}
+
+// Check if a user has the admin role.
+func (d *DbManager) IsUserAdmin(user User) (bool, error) {
+	query :=
+		`SELECT
+			1
+		FROM
+			userroles
+			INNER JOIN users ON userroles.user_id = users.user_id
+			INNER JOIN roles ON userroles.role_id = roles.role_id
+		WHERE users.user_id = $1 AND roles.role_name = 'admin'
+		LIMIT 1`
+
+	var exists int
+	err := d.Connection.QueryRow(d.context, query, user.Id).Scan(&exists)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	return true, nil
 }
 
 // Update a user, expects pre-hashed password (do not give this plaintext pls)
@@ -599,7 +625,7 @@ func (d *DbManager) ListCustomQueries() ([]Query, error) {
 
 func (d *DbManager) ExecuteCustomQuery(query string) ([]map[string]string, error) {
 	if d == nil {
-		return nil, errors.New("This service has not been connected to a data-only database.\nUse POST /settings/cdb to set the postgres connection string.")
+		return nil, errors.New("this service has not been connected to a data-only database.\nUse POST /settings/cdb to set the postgres connection string")
 	}
 
 	var retRows []map[string]string

--- a/ui/src/components/AdminRoles.vue
+++ b/ui/src/components/AdminRoles.vue
@@ -66,7 +66,7 @@ function submitEdit() {
         body.permissions = selectedPermissions.value;
     }
 
-    let route = "/role/" + body.id; 
+    let route = "/admin/role/" + body.id; 
     apiFetch(route, "PATCH", JSON.stringify(body))
         .then((response) => {
             if (!response.ok) {
@@ -115,7 +115,7 @@ function submitCreate() {
         body.permissions = selectedPermissions.value;
     }
 
-    apiFetch("/role", "POST", JSON.stringify(body))
+    apiFetch("/admin/role", "POST", JSON.stringify(body))
         .then((response) => {
             if (!response.ok) {
                 toastRef.value?.showToast(
@@ -146,7 +146,7 @@ function showDelete(id) {
 
 // Send DELETE role request to backend API
 function submitDelete() {
-    const route = "/role/" + tempRole.value.id;
+    const route = "/admin/role/" + tempRole.value.id;
     apiFetch(route, "DELETE")
         .then((response) => {
             if (!response.ok) {
@@ -171,7 +171,7 @@ function submitDelete() {
 
 // Get all global permissions
 function loadPermissions() {
-    const route = "/permissions/global";
+    const route = "/admin/permissions/global";
     apiFetch(route)
     .then(async (response) => {
         if (!response.ok) {
@@ -222,7 +222,7 @@ function togglePermission(permissionId, checked) {
 
 // Fetch roles from backend API
 function loadRoles() {
-    apiFetch("/roles")
+    apiFetch("/admin/roles")
         .then(async (response) => {
             if (!response.ok) {
                 toastRef.value?.showToast(

--- a/ui/src/components/AdminSettings.vue
+++ b/ui/src/components/AdminSettings.vue
@@ -41,7 +41,7 @@ function submitEdit(key) {
     let value = document.getElementById(`setting-${key}`).value
     console.log(value);
  
-    apiFetch(`/settings/${key}`, "PATCH", value)
+    apiFetch(`/admin/settings/${key}`, "PATCH", value)
         .then((response) => {
             if (!response.ok) {
                 toastRef.value?.showToast(
@@ -65,7 +65,7 @@ function submitEdit(key) {
 
 // Fetch roles from backend API
 function loadSettings() {
-    apiFetch("/settings")
+    apiFetch("/admin/settings")
         .then(async (response) => {
             
             if (!response.ok) {

--- a/ui/src/components/AdminUsers.vue
+++ b/ui/src/components/AdminUsers.vue
@@ -50,7 +50,7 @@ function addUser(user) {
 	}
 
 	// submit user and pass to form
-	apiFetch('/signup', 'POST', JSON.stringify(body))
+	apiFetch('/admin/signup', 'POST', JSON.stringify(body))
 		.then((response) => {
 			if (!response.ok) {
 				toastRef.value?.showToast(
@@ -76,7 +76,7 @@ function addUser(user) {
 
 function deleteUser(username) {
 
-	apiFetch(`/user/${username}`, "DELETE")
+	apiFetch(`/admin/user/${username}`, "DELETE")
 		.then((res) => {
 			if (!res.ok) {
 				toastRef.value?.showToast(
@@ -101,7 +101,7 @@ function deleteUser(username) {
 }
 
 function loadUsers() {
-	apiFetch('/users', 'GET')
+	apiFetch('/admin/users', 'GET')
 		.then(async (response) => {
 			// Handle error
 			if (!response.ok) {
@@ -120,7 +120,7 @@ function loadUsers() {
 }
 
 function loadRoles() {
-	apiFetch('/roles', 'GET').then(async res => {
+	apiFetch('/admin/roles', 'GET').then(async res => {
 		let val = await res.json();
 		roleList.value = val;
 
@@ -131,7 +131,7 @@ function loadRoles() {
 }
 
 function addUserRole(uid, rid) {
-	apiFetch(`/user/${uid}/role/${rid}`, 'POST').then((res) => {
+	apiFetch(`/admin/user/${uid}/role/${rid}`, 'POST').then((res) => {
 		if (res.ok) {
 			loadUsers()
 		} else {
@@ -141,7 +141,7 @@ function addUserRole(uid, rid) {
 }
 
 function removeUserRole(uid, rid) {
-	apiFetch(`/user/${uid}/role/${rid}`, 'DELETE').then((res) => {
+	apiFetch(`/admin/user/${uid}/role/${rid}`, 'DELETE').then((res) => {
 
 		if (res.ok) {
 			loadUsers()
@@ -170,7 +170,7 @@ function submitEdit() {
 		body.password = tempUser.value.password
 	}
 
-	let route = "/user/" + body.id;
+	let route = "/admin/user/" + body.id;
 	apiFetch(route, "PATCH", JSON.stringify(body))
 		.then((response) => {
 			if (!response.ok) {

--- a/ui/src/components/Navbar.vue
+++ b/ui/src/components/Navbar.vue
@@ -94,7 +94,7 @@ loadDashboards();
             <img src="@/assets/StrataFullx256.png" alt="STRATA" class="mx-auto w-5/6 pt-2"></img>
         </SidebarHeader>
         <SidebarContent>
-            <SidebarGroup>
+            <SidebarGroup v-if="user.isAdmin">
                 <SidebarGroupLabel>Administration</SidebarGroupLabel>
                 <SidebarGroupContent>
                     <SidebarMenu>

--- a/ui/src/stores/user.js
+++ b/ui/src/stores/user.js
@@ -3,10 +3,12 @@ import { defineStore } from 'pinia'
 
 export const useUserStore = defineStore('user', () => {
   const username = ref("")
+  const isAdmin = ref(false);
 
   if (localStorage.getItem('user')) {
     const stored = JSON.parse(localStorage.getItem('user'))
     username.value = stored.username || "";
+    isAdmin.value = stored.isAdmin || false;
   }
 
   const isLoggedIn = computed(() => {

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -15,13 +15,22 @@ async function login() {
         username: user.value,
         password: pass.value
     }
-    await apiFetch('/login', 'POST', JSON.stringify(body), false).then(res => {
+    await apiFetch('/login', 'POST', JSON.stringify(body), false).then(async res => {
         if (res.status == 200) {
             store.username = user.value;
             router.push("/");
+            let resBody = await res.json();
+            if (resBody.isAdmin) {
+                store.isAdmin = true;
+            } else {
+                store.isAdmin = false;
+            }
         } else {
             error = true;
+            throw new Error("error: expected 200, received " + res.status)
         }
+    }).catch(err => {
+        console.log(err);
     })
 
 }


### PR DESCRIPTION
## Changes made
- Backend:
  - `activeUsers` map also stores if the user is an admin in a bool.
  - Returns it in the body `/login` route (`{ "isAdmin": bool }`).
- Frontend
  - Saves the `isAdmin` value in the `user` pinia store.
  - Conditionally render the Admin settings elements in the `Navbar` if it's true. 
- SQL scripts
  - Simplified `1_schema.sql`, which now drops the entire `strata.public` schema (ensures that every table, type, value is dropped).
  - Gave the `admin` role all permissions by default. 