### PR TITLE
fix: corrected state sync issue when saving queries

### DIFF
--- a/ui/src/components/Queries.vue
+++ b/ui/src/components/Queries.vue
@@ -63,6 +63,7 @@ function quickSave() {
 				);
 
 				tabManager.getTabById(tabManager.currentTab).savedLiteral = code.value;
+				loadQueries();
 			})
 			.catch((error) => {
 				console.error("Error:", error);


### PR DESCRIPTION
Literally a 1 line fix because I forgot to sync the state of the query browser with the database on update

close #140 