### PR TITLE
Reuse valid UUID tokens

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -18,6 +18,7 @@ import (
 )
 
 type UserSessionData struct {
+	Id      int
 	Name    string
 	IsAdmin bool
 }
@@ -65,7 +66,7 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]UserSessionData)
 			return
 		}
 
-		newId := addNewUUID(user.Name, isAdmin, activeUsers)
+		newId := addNewUUID(user.Id, user.Name, isAdmin, activeUsers)
 		c.SetCookie(
 			uuidTag,
 			newId,
@@ -124,7 +125,7 @@ func LogoutHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 // @Router /auth [get]
 func AuthHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		uuid, err := c.Cookie(uuidTag)
+		userUUID, err := c.Cookie(uuidTag)
 		if err != nil {
 			errMsg := fmt.Sprintf("expected a uuid cookie: %s", err.Error())
 			c.String(http.StatusBadRequest, errMsg)
@@ -132,7 +133,7 @@ func AuthHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 			return
 		}
 
-		_, exists := activeUsers[uuid]
+		_, exists := activeUsers[userUUID]
 		if !exists {
 			c.String(http.StatusUnauthorized, "uuid not valid")
 			c.Abort()
@@ -185,18 +186,24 @@ func PingHandler(c *gin.Context) {
 }
 
 // Generate UUID if user does not already have one
-func addNewUUID(username string, isAdmin bool, users map[string]UserSessionData) string {
-	newId := uuid.NewString()
-	for _, ok := users[newId]; ok; {
-		newId = uuid.NewString()
+func addNewUUID(userId int, username string, isAdmin bool, users map[string]UserSessionData) string {
+	for sessionUUID, session := range users {
+		if userId == session.Id {
+			return sessionUUID
+		}
 	}
 
-	users[newId] = UserSessionData{
+	newUUId := uuid.NewString()
+	for _, ok := users[newUUId]; ok; {
+		newUUId = uuid.NewString()
+	}
+
+	users[newUUId] = UserSessionData{
 		Name:    username,
 		IsAdmin: isAdmin,
 	}
 
-	return newId
+	return newUUId
 }
 
 func GetAllSettingsHandler(d *database.DbManager) gin.HandlerFunc {

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -39,7 +39,7 @@ func SignUpHandler(d *database.DbManager, activeUsers map[string]UserSessionData
 			return
 		}
 
-		err = d.InsertUser(user.Name, hash)
+		user, err = d.InsertUser(user.Name, hash)
 		if err != nil {
 			errMsg := fmt.Sprintf("unable to add user to database: %s", err.Error())
 			c.String(http.StatusInternalServerError, errMsg)
@@ -53,7 +53,7 @@ func SignUpHandler(d *database.DbManager, activeUsers map[string]UserSessionData
 			return
 		}
 
-		newId := addNewUUID(user.Name, isAdmin, activeUsers)
+		newId := addNewUUID(user.Id, user.Name, isAdmin, activeUsers)
 		c.SetCookie(
 			uuidTag,
 			newId,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -204,7 +204,7 @@ func (d *DbManager) GetSingleUser(name string) (User, error) {
 }
 
 // Insert user into the database. Expects the password to be hashed using the auth module.
-func (d *DbManager) InsertUser(username string, password string) error {
+func (d *DbManager) InsertUser(username string, password string) (User, error) {
 	user := User{}
 	query :=
 		`INSERT INTO users (user_name, password_hash)
@@ -214,7 +214,7 @@ func (d *DbManager) InsertUser(username string, password string) error {
 	var userId int
 	err := d.Connection.QueryRow(d.context, query, username, password).Scan(&userId, &user.Name, &user.Password)
 	if err != nil {
-		return err
+		return User{}, err
 	}
 
 	query =
@@ -230,10 +230,10 @@ func (d *DbManager) InsertUser(username string, password string) error {
 
 	_, err = d.Connection.Query(d.context, query, userId)
 	if err != nil {
-		return err
+		return User{}, err
 	}
 
-	return nil
+	return user, nil
 }
 
 // Delete a user from the database by username

--- a/pkg/test/database_test.go
+++ b/pkg/test/database_test.go
@@ -105,7 +105,7 @@ func Test_DeleteUser(t *testing.T) {
 		Name:     "testDelete",
 		Password: "testDelete",
 	}
-	err = db.InsertUser(testUser.Name, testUser.Password)
+	_, err = db.InsertUser(testUser.Name, testUser.Password)
 	if err != nil {
 		t.Fatalf("error inserting test user into database: %s", err.Error())
 	}
@@ -133,7 +133,7 @@ func Test_AddUserRole(t *testing.T) {
 		Name:     "testAddRole",
 		Password: password_hash,
 	}
-	err = db.InsertUser(testUser.Name, testUser.Password)
+	_, err = db.InsertUser(testUser.Name, testUser.Password)
 	if err != nil {
 		t.Fatalf("error inserting test user into database: %s", err.Error())
 	}
@@ -164,7 +164,7 @@ func Test_DeleteUserRole(t *testing.T) {
 		Name:     "testDeleteRole",
 		Password: password_hash,
 	}
-	err = db.InsertUser(testUser.Name, testUser.Password)
+	_, err = db.InsertUser(testUser.Name, testUser.Password)
 	if err != nil {
 		t.Fatalf("error inserting test user into database: %s", err.Error())
 	}


### PR DESCRIPTION
`addNewUUID` made a new UUID for each valid login request.

It should reuse the same UUID if the user already has an active session.

## Changes made
- Update `addNewUUID` to check if user has existing UUID token, if so resend that in `LoginHandler` response.
- Update `database.InsertUser` so that it returns the inserted user.
- Update related unit tests.