### PR TITLE
Refactor backend

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,161 +1,120 @@
 package main
 
 import (
-	"context"
 	"log"
-	"time"
 
 	_ "github.com/TeamStrata/strata/docs"
 	"github.com/TeamStrata/strata/pkg/api"
-	"github.com/TeamStrata/strata/pkg/database"
-	"github.com/gin-contrib/cors"
-	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 func main() {
-	server := gin.Default()
-
-	//cors config (redux)
-	config := cors.Config{
-		AllowOrigins:     []string{"http://localhost:5173"},
-		AllowMethods:     []string{"GET", "PATCH", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
-		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
-	}
-	server.Use(cors.New(config))
-
-	// Get database connection string
-	conStr, err := database.GetConnectionString(database.DefaultPath)
+	server, err := api.InitServer()
 	if err != nil {
-		log.Fatalf("error loading .env file: %s", err.Error())
-	}
-
-	// Initialize database manager
-	db, err := database.NewDbManager(conStr, context.Background())
-	if err != nil {
-		log.Fatalf("error initializing DB manager: %s", err.Error())
-	}
-
-	// Create the client database which will be used for custom queries
-	cdb_str, cerr := db.GetSetting("cdb")
-	if cerr != nil {
-		log.Printf("error reading DB settings: %s", cerr.Error())
+		log.Printf("error initializing server: %s", err.Error())
 		return
 	}
 
-	cdb, cerr := database.NewDbManager(cdb_str, context.Background())
-	if cerr != nil {
-		log.Printf("error initializing client DB manager: %s", cerr.Error())
-		return
-	}
+	// Frontend assets
+	server.Engine.Static("/assets", "ui/dist/assets")
+	server.Engine.StaticFile("/", "ui/dist/index.html")
+	server.Engine.StaticFile("/favicon.ico", "ui/dist/favicon.ico")
 
-	// Map for active users and uuids
-	// key: uuid
-	// value: username
-	activeUsers := make(map[string]api.UserSessionData)
-
-	// Frontend
-	server.Static("/assets", "ui/dist/assets")
-	server.StaticFile("/", "ui/dist/index.html")
-	server.StaticFile("/favicon.ico", "ui/dist/favicon.ico")
-
-	// Documenation Endpoints
-	server.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	// Documenation endpoints
+	server.Engine.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	// Auth endpoints
-	server.POST("/login", api.LoginHandler(db, activeUsers))
+	server.Engine.POST("/login", server.LoginHandler)
 
-	protected := server.Group("/api")
+	protected := server.Engine.Group("/api")
 	{
-		protected.Use(api.AuthHandler(activeUsers))
+		protected.Use(server.AuthHandler)
 
 		// Auth routes
-		protected.POST("/logout", api.LogoutHandler(activeUsers))
-		protected.POST("/auth", api.AuthHandler(activeUsers))
-		protected.GET("/isadmin/:uname", api.IsAdminHandler(activeUsers))
+		protected.POST("/logout", server.LogoutHandler)
+		protected.POST("/auth", server.AuthHandler)
+		protected.GET("/isadmin/:uname", server.IsAdminHandler)
 
 		// Dashboard Components
-		/// Charts
-		protected.GET("/charts", api.GetChartListHandler(db))
-		protected.GET("/chart/:cid", api.GetChartHandler(db))
-		protected.POST("/chart", api.CreateChartHandler(db))
-		protected.DELETE("/chart/:cid", api.DeleteChartHandler(db))
-		protected.PATCH("/chart/:cid", api.UpdateChartHandler(db))
-		/// Chart Series
-		protected.GET("/chart/:cid/series", api.GetChartSeriesListHandler(db))
-		protected.GET("/chart/:cid/series/:sid", api.GetChartSingleSeriesHandler(db))
-		protected.POST("/chart/:cid/series", api.AddChartSeriesHandler(db))
-		protected.DELETE("/chart/:cid/series/:sid", api.DeleteChartSingleSeriesHandler(db))
-		protected.PATCH("/chart/:cid/series/:sid", api.UpdateChartSeriesHandler(db))
-		protected.DELETE("/chart/:cid/series", api.DeleteAllChartSeriesHandler(db))
-		/// Dashboard itself
-		protected.GET("/dashboards", api.GetDashboardListHandler(db, activeUsers))
-		protected.GET("/dashboard/:did", api.GetDashboardHandler(db))
-		protected.POST("/dashboard", api.CreateDashboardPageHandler(db))
-		protected.DELETE("/dashboard/:did", api.DeleteDashboardHandler(db))
-		protected.GET("/dashboard/:did/charts", api.ListDashboardChartsHandler(db))
-		protected.PATCH("/dashboard/:did/chart/:cid", api.AppendChartToDashboardHandler(db))
-		protected.DELETE("/dashboard/:did/chart/:cid", api.RemoveChartFromDashboardHandler(db))
-
-		protected.GET("/dashboard/:did/permissions", api.GetDashboardRolePermissionsHandler(db))
-		protected.PATCH("/dashboard", api.UpdateDashboardHandler(db))
+		// Charts
+		protected.GET("/charts", server.GetChartListHandler)
+		protected.GET("/chart/:cid", server.GetChartHandler)
+		protected.POST("/chart", server.CreateChartHandler)
+		protected.DELETE("/chart/:cid", server.DeleteChartHandler)
+		protected.PATCH("/chart/:cid", server.UpdateChartHandler)
+		// Chart Series
+		protected.GET("/chart/:cid/series", server.GetChartSeriesListHandler)
+		protected.GET("/chart/:cid/series/:sid", server.GetChartSingleSeriesHandler)
+		protected.POST("/chart/:cid/series", server.AddChartSeriesHandler)
+		protected.DELETE("/chart/:cid/series/:sid", server.DeleteChartSingleSeriesHandler)
+		protected.PATCH("/chart/:cid/series/:sid", server.UpdateChartSeriesHandler)
+		protected.DELETE("/chart/:cid/series", server.DeleteAllChartSeriesHandler)
+		// Dashboard itself
+		protected.GET("/dashboards", server.GetDashboardListHandler)
+		protected.GET("/dashboard/:did", server.GetDashboardHandler)
+		protected.POST("/dashboard", server.CreateDashboardPageHandler)
+		protected.DELETE("/dashboard/:did", server.DeleteDashboardHandler)
+		protected.GET("/dashboard/:did/charts", server.ListDashboardChartsHandler)
+		protected.PATCH("/dashboard/:did/chart/:cid", server.AppendChartToDashboardHandler)
+		protected.DELETE("/dashboard/:did/chart/:cid", server.RemoveChartFromDashboardHandler)
+		// Fashboard
+		protected.GET("/dashboard/:did/permissions", server.GetDashboardRolePermissionsHandler)
+		protected.PATCH("/dashboard", server.UpdateDashboardHandler)
 
 		// Query Endpoints
-		protected.GET("/queries", api.GetQueryList(db))
-		protected.POST("/query/executeLiteral", api.ExecuteQueryLiteralHandler(&cdb)) // Execute a saved query (custom or standard saved queries)
-		protected.GET("/query/:qid", api.ReadQueryLiteralHandler(db))                 // Return the query SQL string
-		protected.GET("/query/:qid/execute", api.ExecuteQueryHandler(db, &cdb))       // Execute a saved query (custom or standard saved queries)
-		protected.POST("/query/:qid", api.SaveQueryHandler(db))
-		protected.DELETE("/query/:qid", api.DeleteQueryHandler(db))
-		protected.PATCH("/query/:qid", api.UpdateQueryHandler(db)) // Update a custom query in the database
+		protected.GET("/queries", server.GetQueryList)
+		protected.POST("/query/executeLiteral", server.ExecuteQueryLiteralHandler) // Execute a saved query (custom or standard saved queries)
+		protected.GET("/query/:qid", server.ReadQueryLiteralHandler)               // Return the query SQL string
+		protected.GET("/query/:qid/execute", server.ExecuteQueryHandler)           // Execute a saved query (custom or standard saved queries)
+		protected.POST("/query/:qid", server.SaveQueryHandler)
+		protected.DELETE("/query/:qid", server.DeleteQueryHandler)
+		protected.PATCH("/query/:qid", server.UpdateQueryHandler) // Update a custom query in the database
 
 		// Misc Endpoints
-		protected.GET("/ping", api.PingHandler)
+		protected.GET("/ping", server.PingHandler)
 
 		// AI
-		protected.POST("/stratabot", api.StrataBotHandler(db))
-		protected.GET("/cdb-schema", api.SchemaDump(&cdb))
+		protected.POST("/stratabot", server.StrataBotHandler)
+		protected.GET("/cdb-schema", server.SchemaDump)
 
 		admin := protected.Group("/admin")
 		{
-			admin.Use(api.AuthHandler(activeUsers))
+			admin.Use(server.AuthHandler)
 
 			// Account creation
-			admin.POST("/signup", api.SignUpHandler(db, activeUsers))
+			admin.POST("/signup", server.SignUpHandler)
 
 			// Users
-			admin.GET("/users", api.GetUsersHandler(db))
-			admin.GET("/user/:uid", api.GetUserHandler(db))
-			admin.DELETE("/user/:uname", api.DeleteUserHandler(db, activeUsers))
-			admin.PATCH("/user/:uid", api.UpdateUserHandler(db))
+			admin.GET("/users", server.GetUsersHandler)
+			admin.GET("/user/:uid", server.GetUserHandler)
+			admin.DELETE("/user/:uname", server.DeleteUserHandler)
+			admin.PATCH("/user/:uid", server.UpdateUserHandler)
 
 			// User roles
-			admin.DELETE("/user/:uname/role/:rname", api.DeleteUserRoleHandler(db))
-			admin.POST("/user/:uname/role/:rname", api.AddUserRoleHandler(db))
+			admin.DELETE("/user/:uname/role/:rname", server.DeleteUserRoleHandler)
+			admin.POST("/user/:uname/role/:rname", server.AddUserRoleHandler)
 
 			// Roles
-			admin.GET("/roles", api.GetRolesHandler(db))
-			admin.POST("/role", api.AddRoleHandler(db))
-			admin.PATCH("/role/:rid", api.UpdateRoleHandler(db))
-			admin.DELETE("/role/:rid", api.DeleteRoleHandler(db))
+			admin.GET("/roles", server.GetRolesHandler)
+			admin.POST("/role", server.AddRoleHandler)
+			admin.PATCH("/role/:rid", server.UpdateRoleHandler)
+			admin.DELETE("/role/:rid", server.DeleteRoleHandler)
 
 			// Permissions
-			admin.GET("/permissions", api.GetPermissionsHandler(db))
-			admin.GET("/permissions/:scope", api.GetScopedPermissionsHandler(db))
-			admin.POST("/dashboard/:did/role/:rid/permission/:pid", api.AddDashboardRolePermissionHandler(db))
-			admin.DELETE("/dashboard/:did/role/:rid/permission/:pid", api.DeleteDashboardRolePermissionHandler(db))
+			admin.GET("/permissions", server.GetPermissionsHandler)
+			admin.GET("/permissions/:scope", server.GetScopedPermissionsHandler)
+			admin.POST("/dashboard/:did/role/:rid/permission/:pid", server.AddDashboardRolePermissionHandler)
+			admin.DELETE("/dashboard/:did/role/:rid/permission/:pid", server.DeleteDashboardRolePermissionHandler)
 
 			// Settings
-			admin.GET("/settings", api.GetAllSettingsHandler(db))
-			admin.GET("/settings/:key", api.GetSettingHandler(db))
-			admin.PATCH("/settings/:key", api.UpdateSettingHandler(db, &cdb))
+			admin.GET("/settings", server.GetAllSettingsHandler)
+			admin.GET("/settings/:key", server.GetSettingHandler)
+			admin.PATCH("/settings/:key", server.UpdateSettingHandler)
 		}
 	}
 
-	err = server.Run(":8080")
+	err = server.Engine.Run(":8080")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,8 @@ func main() {
 		protected.GET("/dashboard/:did/charts", server.ListDashboardChartsHandler)
 		protected.PATCH("/dashboard/:did/chart/:cid", server.AppendChartToDashboardHandler)
 		protected.DELETE("/dashboard/:did/chart/:cid", server.RemoveChartFromDashboardHandler)
-		// Fashboard
+		protected.GET("/dashboard/:did/full", server.GetFullDashboardData)
+		// Dashboard permissions
 		protected.GET("/dashboard/:did/permissions", server.GetDashboardRolePermissionsHandler)
 		protected.PATCH("/dashboard", server.UpdateDashboardHandler)
 

--- a/pkg/api/dashcharts.go
+++ b/pkg/api/dashcharts.go
@@ -10,455 +10,418 @@ import (
 )
 
 // / Charts
-func GetChartListHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		charts, err := d.ListAllCharts()
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		data, err := json.Marshal(charts)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+func (server *Server) GetChartListHandler(c *gin.Context) {
+	charts, err := server.Db.ListAllCharts()
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
 		c.Done()
+		return
 	}
+
+	data, err := json.Marshal(charts)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func GetChartHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		chart, err := d.GetChart(chart_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		data, err := json.Marshal(chart)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+func (server *Server) GetChartHandler(c *gin.Context) {
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	chart, err := server.Db.GetChart(chart_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	data, err := json.Marshal(chart)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func CreateChartHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart := database.Chart{}
-		err := c.ShouldBindJSON(&chart)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-
-		// Validate chart data
-		if chart.Title == "" || chart.Type == "" || chart.Xname == "" || chart.Yname == "" {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-
-		// Inserting custom query
-		id, err := d.InsertChart(chart)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
-		c.Done()
+func (server *Server) CreateChartHandler(c *gin.Context) {
+	chart := database.Chart{}
+	err := c.ShouldBindJSON(&chart)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
 	}
+
+	// Validate chart data
+	if chart.Title == "" || chart.Type == "" || chart.Xname == "" || chart.Yname == "" {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	// Inserting custom query
+	id, err := server.Db.InsertChart(chart)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+	c.Done()
 }
 
-func DeleteChartHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		err = d.DeleteChart(chart_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+func (server *Server) DeleteChartHandler(c *gin.Context) {
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	err = server.Db.DeleteChart(chart_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
-func UpdateChartHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		var chart database.Chart
-		if err := c.ShouldBindJSON(&chart); err != nil {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-		chart.Id = chart_id
-
-		err = d.UpdateChart(chart)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+func (server *Server) UpdateChartHandler(c *gin.Context) {
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	var chart database.Chart
+	if err := c.ShouldBindJSON(&chart); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	chart.Id = chart_id
+
+	err = server.Db.UpdateChart(chart)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
 // / Chart Series
-func GetChartSeriesListHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		series, err := d.ListChartSeries(chart_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.JSON(200, series)
+func (server *Server) GetChartSeriesListHandler(c *gin.Context) {
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
 	}
+
+	series, err := server.Db.ListChartSeries(chart_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.JSON(200, series)
 }
 
-func GetChartSingleSeriesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		series_id_str := c.Param("sid")
-		series_id, err := strconv.Atoi(series_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		series, err := d.GetChartSeries(series_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		data, err := json.Marshal(series)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+func (server *Server) GetChartSingleSeriesHandler(c *gin.Context) {
+	series_id_str := c.Param("sid")
+	series_id, err := strconv.Atoi(series_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	series, err := server.Db.GetChartSeries(series_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	data, err := json.Marshal(series)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func AddChartSeriesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-
-		var series []database.ChartSeries
-		if err := c.ShouldBindJSON(&series); err != nil {
-			c.Data(http.StatusBadRequest, "text/plain", []byte("ShouldBindJSON Error"))
-			return
-		}
-
-		id, err := d.InsertChartSeries(series)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
-		c.Done()
+func (server *Server) AddChartSeriesHandler(c *gin.Context) {
+	var series []database.ChartSeries
+	if err := c.ShouldBindJSON(&series); err != nil {
+		c.Data(http.StatusBadRequest, "text/plain", []byte("ShouldBindJSON Error"))
+		return
 	}
+
+	id, err := server.Db.InsertChartSeries(series)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+	c.Done()
 }
 
-func DeleteChartSingleSeriesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		series_id_str := c.Param("sid")
-		series_id, err := strconv.Atoi(series_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		err = d.DeleteChartSeries(series_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+func (server *Server) DeleteChartSingleSeriesHandler(c *gin.Context) {
+	series_id_str := c.Param("sid")
+	series_id, err := strconv.Atoi(series_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	err = server.Db.DeleteChartSeries(series_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
-func UpdateChartSeriesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		series_id_str := c.Param("sid")
-		series_id, err := strconv.Atoi(series_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		var series database.ChartSeries
-		if err := c.ShouldBindJSON(&series); err != nil {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-		series.Id = series_id
-
-		err = d.UpdateChartSeries(series)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+func (server *Server) UpdateChartSeriesHandler(c *gin.Context) {
+	series_id_str := c.Param("sid")
+	series_id, err := strconv.Atoi(series_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The series ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	var series database.ChartSeries
+	if err := c.ShouldBindJSON(&series); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	series.Id = series_id
+
+	err = server.Db.UpdateChartSeries(series)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
-func DeleteAllChartSeriesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
-			c.Done()
-			return
-		}
-
-		err = d.DeleteAllChartSeries(chart_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+func (server *Server) DeleteAllChartSeriesHandler(c *gin.Context) {
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
 		c.Done()
+		return
 	}
+
+	err = server.Db.DeleteAllChartSeries(chart_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
 // Dashboard itself
-func GetDashboardListHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		userId, err := c.Cookie(uuidTag)
-		if err != nil {
-			c.String(http.StatusBadRequest, "missing uuid cookie")
-			return
-		}
-
-		user, exists := activeUsers[userId]
-		if !exists {
-			c.String(http.StatusForbidden, "invalid uuid cookie")
-		}
-
-		dashboards, err := d.GetUserDashboardPermissions(user.Id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error:"+err.Error()))
-			c.Done()
-			return
-		}
-		data, err := json.Marshal(dashboards)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"+err.Error()))
-			c.Done()
-			return
-		}
-		c.Data(200, "application/json", data)
-		c.Done()
+func (server *Server) GetDashboardListHandler(c *gin.Context) {
+	userId, err := c.Cookie(uuidTag)
+	if err != nil {
+		c.String(http.StatusBadRequest, "missing uuid cookie")
+		return
 	}
+
+	user, exists := server.ActiveUsers[userId]
+	if !exists {
+		c.String(http.StatusForbidden, "invalid uuid cookie")
+	}
+
+	dashboards, err := server.Db.GetUserDashboardPermissions(user.Id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error:"+err.Error()))
+		c.Done()
+		return
+	}
+	data, err := json.Marshal(dashboards)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"+err.Error()))
+		c.Done()
+		return
+	}
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func GetDashboardHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id_str := c.Param("did")
-		dash_id, err := strconv.Atoi(dash_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
-			c.Done()
-			return
-		}
-		dash, err := d.GetDashboard(dash_id)
-		if err != nil {
-			c.Data(404, "text/plain", []byte("Dashboard not found"))
-			c.Done()
-			return
-		}
-		data, err := json.Marshal(dash)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"))
-			c.Done()
-			return
-		}
-		c.Data(200, "application/json", data)
+func (server *Server) GetDashboardHandler(c *gin.Context) {
+	dash_id_str := c.Param("did")
+	dash_id, err := strconv.Atoi(dash_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
 		c.Done()
+		return
 	}
+	dash, err := server.Db.GetDashboard(dash_id)
+	if err != nil {
+		c.Data(404, "text/plain", []byte("Dashboard not found"))
+		c.Done()
+		return
+	}
+	data, err := json.Marshal(dash)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"))
+		c.Done()
+		return
+	}
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func CreateDashboardPageHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		var dash database.Dashboard
-		if err := c.ShouldBindJSON(&dash); err != nil {
-			c.Data(400, "text/plain", []byte("Invalid dashboard data"))
-			return
-		}
-		id, err := d.InsertDashboard(dash)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"))
-			c.Done()
-			return
-		}
-		c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
-		c.Done()
+func (server *Server) CreateDashboardPageHandler(c *gin.Context) {
+	var dash database.Dashboard
+	if err := c.ShouldBindJSON(&dash); err != nil {
+		c.Data(400, "text/plain", []byte("Invalid dashboard data"))
+		return
 	}
+	id, err := server.Db.InsertDashboard(dash)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"))
+		c.Done()
+		return
+	}
+	c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+	c.Done()
 }
 
-func DeleteDashboardHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id_str := c.Param("did")
-		dash_id, err := strconv.Atoi(dash_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
-			c.Done()
-			return
-		}
-		err = d.DeleteDashboard(dash_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"))
-			c.Done()
-			return
-		}
-		c.Status(200)
+func (server *Server) DeleteDashboardHandler(c *gin.Context) {
+	dash_id_str := c.Param("did")
+	dash_id, err := strconv.Atoi(dash_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
 		c.Done()
+		return
 	}
+	err = server.Db.DeleteDashboard(dash_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"))
+		c.Done()
+		return
+	}
+	c.Status(200)
+	c.Done()
 }
 
-func ListDashboardChartsHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id_str := c.Param("did")
-		dash_id, err := strconv.Atoi(dash_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
-			c.Done()
-			return
-		}
-		charts, err := d.ListDashboardCharts(dash_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-		data, err := json.Marshal(charts)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-		c.Data(200, "application/json", data)
+func (server *Server) ListDashboardChartsHandler(c *gin.Context) {
+	dash_id_str := c.Param("did")
+	dash_id, err := strconv.Atoi(dash_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
 		c.Done()
+		return
 	}
+	charts, err := server.Db.ListDashboardCharts(dash_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+	data, err := json.Marshal(charts)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func AppendChartToDashboardHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id, err := strconv.Atoi(c.Param("did"))
-		if err != nil {
-			c.String(400, "The dashboard ID must be an integer!")
-			return
-		}
-		chart_id, err := strconv.Atoi(c.Param("cid"))
-		if err != nil {
-			c.String(400, "The chart ID must be an integer!")
-			return
-		}
-
-		var body struct {
-			SizeX int `json:"size_x"`
-			SizeY int `json:"size_y"`
-		}
-		if err := c.BindJSON(&body); err != nil {
-			c.String(400, "Invalid JSON payload")
-			return
-		}
-
-		err = d.AppendChartToDashboard(dash_id, chart_id, body.SizeX, body.SizeY)
-		if err != nil {
-			c.String(500, err.Error())
-			return
-		}
-		c.Status(200)
+func (server *Server) AppendChartToDashboardHandler(c *gin.Context) {
+	dash_id, err := strconv.Atoi(c.Param("did"))
+	if err != nil {
+		c.String(400, "The dashboard ID must be an integer!")
+		return
 	}
+	chart_id, err := strconv.Atoi(c.Param("cid"))
+	if err != nil {
+		c.String(400, "The chart ID must be an integer!")
+		return
+	}
+
+	var body struct {
+		SizeX int `json:"size_x"`
+		SizeY int `json:"size_y"`
+	}
+	if err := c.BindJSON(&body); err != nil {
+		c.String(400, "Invalid JSON payload")
+		return
+	}
+
+	err = server.Db.AppendChartToDashboard(dash_id, chart_id, body.SizeX, body.SizeY)
+	if err != nil {
+		c.String(500, err.Error())
+		return
+	}
+	c.Status(200)
 }
 
-func RemoveChartFromDashboardHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id_str := c.Param("did")
-		dash_id, err := strconv.Atoi(dash_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
-			c.Done()
-			return
-		}
-		chart_id_str := c.Param("cid")
-		chart_id, err := strconv.Atoi(chart_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
-			c.Done()
-			return
-		}
-		err = d.RemoveChartFromDashboard(dash_id, chart_id)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"))
-			c.Done()
-			return
-		}
-		c.Status(200)
+func (server *Server) RemoveChartFromDashboardHandler(c *gin.Context) {
+	dash_id_str := c.Param("did")
+	dash_id, err := strconv.Atoi(dash_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
 		c.Done()
+		return
 	}
+	chart_id_str := c.Param("cid")
+	chart_id, err := strconv.Atoi(chart_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The chart ID must be an integer!"))
+		c.Done()
+		return
+	}
+	err = server.Db.RemoveChartFromDashboard(dash_id, chart_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"))
+		c.Done()
+		return
+	}
+	c.Status(200)
+	c.Done()
 }

--- a/pkg/api/dashcharts.go
+++ b/pkg/api/dashcharts.go
@@ -426,115 +426,108 @@ func (server *Server) RemoveChartFromDashboardHandler(c *gin.Context) {
 	c.Done()
 }
 
-func GetFullDashboardData(d *database.DbManager, cdb **database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dash_id_str := c.Param("did")
-		dash_id, err := strconv.Atoi(dash_id_str)
-		if err != nil {
-			c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
-			c.Done()
-			return
-		}
+func (server *Server) GetFullDashboardData(c *gin.Context) {
+	dash_id_str := c.Param("did")
+	dash_id, err := strconv.Atoi(dash_id_str)
+	if err != nil {
+		c.Data(400, "text/plain", []byte("The dashboard ID must be an integer!"))
+		c.Done()
+		return
+	}
 
-		dash, err := d.GetDashboard(dash_id)
+	dash, err := server.Db.GetDashboard(dash_id)
+	if err != nil {
+		c.Data(404, "text/plain", []byte("Dashboard not found"))
+		c.Done()
+		return
+	}
+	charts, err := server.Db.ListDashboardCharts(dash_id)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	type SeriesRow = map[string]any
+
+	type SeriesWithData struct {
+		database.ChartSeries             // embed existing fields (id, name, query_id, etc.)
+		Data                 []SeriesRow `json:"data,omitempty"`  // attach query results here
+		Error                string      `json:"error,omitempty"` // optional per-series error
+	}
+
+	// For each chart, fetch its series and axis names
+	type ChartWithSeries struct {
+		ChartId int              `json:"chart_id"`
+		SizeX   int              `json:"size_x"`
+		SizeY   int              `json:"size_y"`
+		Order   int              `json:"order"`
+		Xname   string           `json:"xname"`
+		Yname   string           `json:"yname"`
+		Title   string           `json:"title"`
+		Type    string           `json:"type"`
+		Series  []SeriesWithData `json:"series"`
+	}
+
+	var chartsWithSeries []ChartWithSeries
+	for _, chart := range charts {
+		series, err := server.Db.ListChartSeries(chart.ChartId)
 		if err != nil {
-			c.Data(404, "text/plain", []byte("Dashboard not found"))
+			c.Data(500, "text/plain", []byte(err.Error()))
 			c.Done()
 			return
 		}
-		charts, err := d.ListDashboardCharts(dash_id)
+		// Get chart details for axis names, title, type
+		chartDetails, err := server.Db.GetChart(chart.ChartId)
 		if err != nil {
 			c.Data(500, "text/plain", []byte(err.Error()))
 			c.Done()
 			return
 		}
 
-		type SeriesRow = map[string]any
-
-		type SeriesWithData struct {
-			database.ChartSeries             // embed existing fields (id, name, query_id, etc.)
-			Data                 []SeriesRow `json:"data,omitempty"`  // attach query results here
-			Error                string      `json:"error,omitempty"` // optional per-series error
-		}
-
-		// For each chart, fetch its series and axis names
-		type ChartWithSeries struct {
-			ChartId int              `json:"chart_id"`
-			SizeX   int              `json:"size_x"`
-			SizeY   int              `json:"size_y"`
-			Order   int              `json:"order"`
-			Xname   string           `json:"xname"`
-			Yname   string           `json:"yname"`
-			Title   string           `json:"title"`
-			Type    string           `json:"type"`
-			Series  []SeriesWithData `json:"series"`
-		}
-
-		var chartsWithSeries []ChartWithSeries
-		for _, chart := range charts {
-			series, err := d.ListChartSeries(chart.ChartId)
+		swd := make([]SeriesWithData, len(series))
+		for i, s := range series {
+			swd[i] = SeriesWithData{ChartSeries: s}
+			rawData, err := server.executeQuery(s.QueryID)
 			if err != nil {
 				c.Data(500, "text/plain", []byte(err.Error()))
 				c.Done()
 				return
 			}
-			// Get chart details for axis names, title, type
-			chartDetails, err := d.GetChart(chart.ChartId)
-			if err != nil {
-				c.Data(500, "text/plain", []byte(err.Error()))
-				c.Done()
-				return
-			}
-
-			swd := make([]SeriesWithData, len(series))
-			for i, s := range series {
-				swd[i] = SeriesWithData{ChartSeries: s}
-				var queryErr error
-				rawData, err := executeQuery(d, cdb, s.QueryID)
-				if err != nil {
-					c.Data(500, "text/plain", []byte(err.Error()))
-					c.Done()
-					return
-				}
-				seriesRows := make([]SeriesRow, len(rawData))
-				for j, row := range rawData {
-					seriesRows[j] = make(SeriesRow)
-					for k, v := range row {
-						seriesRows[j][k] = v
-					}
-				}
-				swd[i].Data = seriesRows
-				if queryErr != nil {
-					c.Data(500, "text/plain", []byte(queryErr.Error()))
-					c.Done()
-					return
+			seriesRows := make([]SeriesRow, len(rawData))
+			for j, row := range rawData {
+				seriesRows[j] = make(SeriesRow)
+				for k, v := range row {
+					seriesRows[j][k] = v
 				}
 			}
-
-			chartsWithSeries = append(chartsWithSeries, ChartWithSeries{
-				ChartId: chart.ChartId,
-				SizeX:   chart.SizeX,
-				SizeY:   chart.SizeY,
-				Order:   chart.Order,
-				Xname:   chartDetails.Xname,
-				Yname:   chartDetails.Yname,
-				Title:   chartDetails.Title,
-				Type:    chartDetails.Type,
-				Series:  swd,
-			})
+			swd[i].Data = seriesRows
 		}
 
-		result := map[string]interface{}{
-			"dashboard": dash,
-			"charts":    chartsWithSeries,
-		}
-		data, err := json.Marshal(result)
-		if err != nil {
-			c.Data(500, "text/plain", []byte("Internal server error"))
-			c.Done()
-			return
-		}
-		c.Data(200, "application/json", data)
-		c.Done()
+		chartsWithSeries = append(chartsWithSeries, ChartWithSeries{
+			ChartId: chart.ChartId,
+			SizeX:   chart.SizeX,
+			SizeY:   chart.SizeY,
+			Order:   chart.Order,
+			Xname:   chartDetails.Xname,
+			Yname:   chartDetails.Yname,
+			Title:   chartDetails.Title,
+			Type:    chartDetails.Type,
+			Series:  swd,
+		})
 	}
+
+	result := map[string]interface{}{
+		"dashboard": dash,
+		"charts":    chartsWithSeries,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		c.Data(500, "text/plain", []byte("Internal server error"))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }

--- a/pkg/api/permissions.go
+++ b/pkg/api/permissions.go
@@ -9,49 +9,45 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetDashboardRolePermissionsHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		idParam := c.Param("did")
-		if idParam == "" {
-			c.String(http.StatusBadRequest, "expected dashboard id route parameter")
-			return
-		}
-		id, err := strconv.Atoi(idParam)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid route parameter, expected integer")
-			return
-		}
-
-		permissions, err := d.GetDashboardRolePermissions(id)
-		if err != nil {
-			c.String(
-				http.StatusInternalServerError,
-				"unable to get dashboard permissions"+err.Error(),
-			)
-			return
-		}
-
-		c.JSON(http.StatusOK, permissions)
+func (server *Server) GetDashboardRolePermissionsHandler(c *gin.Context) {
+	idParam := c.Param("did")
+	if idParam == "" {
+		c.String(http.StatusBadRequest, "expected dashboard id route parameter")
+		return
 	}
+	id, err := strconv.Atoi(idParam)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid route parameter, expected integer")
+		return
+	}
+
+	permissions, err := server.Db.GetDashboardRolePermissions(id)
+	if err != nil {
+		c.String(
+			http.StatusInternalServerError,
+			"unable to get dashboard permissions"+err.Error(),
+		)
+		return
+	}
+
+	c.JSON(http.StatusOK, permissions)
 }
 
-func UpdateDashboardHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dashboardData := database.DashboardRolePermissions{}
-		err := c.ShouldBindJSON(&dashboardData)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid JSON body: "+err.Error())
-			return
-		}
-
-		err = d.UpdateDashboardRolePermissions(dashboardData)
-		if err != nil {
-			c.String(http.StatusBadRequest, "unable to update dashboard permissions: "+err.Error())
-			return
-		}
-
-		c.Status(http.StatusOK)
+func (server *Server) UpdateDashboardHandler(c *gin.Context) {
+	dashboardData := database.DashboardRolePermissions{}
+	err := c.ShouldBindJSON(&dashboardData)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
 	}
+
+	err = server.Db.UpdateDashboardRolePermissions(dashboardData)
+	if err != nil {
+		c.String(http.StatusBadRequest, "unable to update dashboard permissions: "+err.Error())
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 // @Summary Get permissions by scope
@@ -63,23 +59,21 @@ func UpdateDashboardHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request - Invalid or missing scope parameter"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /permissions/{scope} [get]
-func GetScopedPermissionsHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		scope := database.StringToScopeType(c.Param("scope"))
-		if scope == database.EmptyScope {
-			c.String(http.StatusBadRequest, "expected route parameter: ':scope'")
-			return
-		}
-
-		permissions, err := d.GetScopedPermissions(scope)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get scoped permissions: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.JSON(http.StatusOK, permissions)
+func (server *Server) GetScopedPermissionsHandler(c *gin.Context) {
+	scope := database.StringToScopeType(c.Param("scope"))
+	if scope == database.EmptyScope {
+		c.String(http.StatusBadRequest, "expected route parameter: ':scope'")
+		return
 	}
+
+	permissions, err := server.Db.GetScopedPermissions(scope)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get scoped permissions: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	c.JSON(http.StatusOK, permissions)
 }
 
 // @Summary Get all permissions
@@ -89,17 +83,15 @@ func GetScopedPermissionsHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {object} []database.Permission "Successfully retrieved all permissions"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /permissions [get]
-func GetPermissionsHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		permissions, err := d.GetPermissions()
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get all permissions: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.JSON(http.StatusOK, permissions)
+func (server *Server) GetPermissionsHandler(c *gin.Context) {
+	permissions, err := server.Db.GetPermissions()
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get all permissions: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.JSON(http.StatusOK, permissions)
 }
 
 // AddDashboardRolePermissionHandler
@@ -115,40 +107,38 @@ func GetPermissionsHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /api/admin/dashboard/{did}/role/{rid}/permission/{pid} [post]
-func AddDashboardRolePermissionHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dashIdStr := c.Param("did")
-		roleIdStr := c.Param("rid")
-		permIdStr := c.Param("pid")
+func (server *Server) AddDashboardRolePermissionHandler(c *gin.Context) {
+	dashIdStr := c.Param("did")
+	roleIdStr := c.Param("rid")
+	permIdStr := c.Param("pid")
 
-		if dashIdStr == "" || roleIdStr == "" || permIdStr == "" {
-			c.String(http.StatusBadRequest, "missing route parameters")
-			return
-		}
-
-		dashId, err := strconv.Atoi(dashIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		roleId, err := strconv.Atoi(roleIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		permId, err := strconv.Atoi(permIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		err = d.AddDashboardRolePermission(dashId, roleId, permId)
-		if err != nil {
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		c.Status(http.StatusOK)
+	if dashIdStr == "" || roleIdStr == "" || permIdStr == "" {
+		c.String(http.StatusBadRequest, "missing route parameters")
+		return
 	}
+
+	dashId, err := strconv.Atoi(dashIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	roleId, err := strconv.Atoi(roleIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	permId, err := strconv.Atoi(permIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	err = server.Db.AddDashboardRolePermission(dashId, roleId, permId)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 // DeleteDashboardRolePermissionHandler
@@ -164,38 +154,36 @@ func AddDashboardRolePermissionHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /api/admin/dashboard/{did}/role/{rid}/permission/{pid} [delete]
-func DeleteDashboardRolePermissionHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		dashIdStr := c.Param("did")
-		roleIdStr := c.Param("rid")
-		permIdStr := c.Param("pid")
+func (server *Server) DeleteDashboardRolePermissionHandler(c *gin.Context) {
+	dashIdStr := c.Param("did")
+	roleIdStr := c.Param("rid")
+	permIdStr := c.Param("pid")
 
-		if dashIdStr == "" || roleIdStr == "" || permIdStr == "" {
-			c.String(http.StatusBadRequest, "missing route parameters")
-			return
-		}
-
-		dashId, err := strconv.Atoi(dashIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		roleId, err := strconv.Atoi(roleIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		permId, err := strconv.Atoi(permIdStr)
-		if err != nil {
-			c.String(http.StatusBadRequest, "invalid dashboard id param")
-		}
-
-		err = d.DeleteDashboardRolePermission(dashId, roleId, permId)
-		if err != nil {
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		c.Status(http.StatusOK)
+	if dashIdStr == "" || roleIdStr == "" || permIdStr == "" {
+		c.String(http.StatusBadRequest, "missing route parameters")
+		return
 	}
+
+	dashId, err := strconv.Atoi(dashIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	roleId, err := strconv.Atoi(roleIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	permId, err := strconv.Atoi(permIdStr)
+	if err != nil {
+		c.String(http.StatusBadRequest, "invalid dashboard id param")
+	}
+
+	err = server.Db.DeleteDashboardRolePermission(dashId, roleId, permId)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/TeamStrata/strata/pkg/database"
 	"github.com/gin-gonic/gin"
 )
 
@@ -18,25 +17,23 @@ import (
 // @Success 200 {array} database.Query "Successfully retrieved users"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /queries [get]
-func GetQueryList(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		queries, err := d.ListCustomQueries()
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		data, err := json.Marshal(queries)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+func (server *Server) GetQueryList(c *gin.Context) {
+	queries, err := server.Db.ListCustomQueries()
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
 		c.Done()
+		return
 	}
+
+	data, err := json.Marshal(queries)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
 // Return the query SQL string
@@ -49,23 +46,21 @@ func GetQueryList(d *database.DbManager) gin.HandlerFunc {
 // @Failure 500 {string} string "Internal Server Error"
 // @Param qid query string true "Query name or ID to retrieve"
 // @Router /query/{qid} [get]
-func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		query_id_str := c.Param("qid")
+func (server *Server) ReadQueryLiteralHandler(c *gin.Context) {
+	query_id_str := c.Param("qid")
 
-		query_name, query_string, err := d.GetCustomQuery(query_id_str)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.JSON(200, gin.H{
-			"name":    query_name,
-			"literal": query_string,
-		})
+	query_name, query_string, err := server.Db.GetCustomQuery(query_id_str)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
 		c.Done()
+		return
 	}
+
+	c.JSON(200, gin.H{
+		"name":    query_name,
+		"literal": query_string,
+	})
+	c.Done()
 }
 
 // Execute a saved query (custom or standard saved queries)
@@ -78,66 +73,62 @@ func ReadQueryLiteralHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 500 {string} string "Internal Server Error"
 // @Param qid query string type "Query name or ID"
 // @Router /query/{qid}/execute [get]
-func ExecuteQueryHandler(d *database.DbManager, cdb **database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		query_id_str := c.Param("qid")
+func (server *Server) ExecuteQueryHandler(c *gin.Context) {
+	query_id_str := c.Param("qid")
 
-		_, query_string, serr := d.GetCustomQuery(query_id_str)
-		if serr != nil {
-			c.Data(500, "text/plain", []byte(serr.Error()))
-			c.Done()
-			return
-		}
-
-		// Perform the custom query
-		rows, qerr := (*cdb).ExecuteCustomQuery(query_string)
-		if qerr != nil {
-			c.Data(500, "text/plain", []byte(qerr.Error()))
-			c.Done()
-			return
-		}
-
-		// Convert the resulting object to JSON
-		data, jerr := json.Marshal(rows)
-		if jerr != nil {
-			c.Data(500, "text/plain", []byte(jerr.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+	_, query_string, serr := server.Db.GetCustomQuery(query_id_str)
+	if serr != nil {
+		c.Data(500, "text/plain", []byte(serr.Error()))
 		c.Done()
+		return
 	}
+
+	// Perform the custom query
+	rows, qerr := server.ClientDb.ExecuteCustomQuery(query_string)
+	if qerr != nil {
+		c.Data(500, "text/plain", []byte(qerr.Error()))
+		c.Done()
+		return
+	}
+
+	// Convert the resulting object to JSON
+	data, jerr := json.Marshal(rows)
+	if jerr != nil {
+		c.Data(500, "text/plain", []byte(jerr.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func ExecuteQueryLiteralHandler(d **database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Read the SQL string from the request body
-		sqlBytes, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-		sqlString := string(sqlBytes)
-
-		rows, qerr := (*d).ExecuteCustomQuery(sqlString)
-		if qerr != nil {
-			c.Data(500, "text/plain", []byte(qerr.Error()))
-			c.Done()
-			return
-		}
-
-		data, jerr := json.Marshal(rows)
-		if jerr != nil {
-			c.Data(500, "text/plain", []byte(jerr.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+func (server *Server) ExecuteQueryLiteralHandler(c *gin.Context) {
+	// Read the SQL string from the request body
+	sqlBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
 		c.Done()
+		return
 	}
+	sqlString := string(sqlBytes)
+
+	rows, qerr := server.ClientDb.ExecuteCustomQuery(sqlString)
+	if qerr != nil {
+		c.Data(500, "text/plain", []byte(qerr.Error()))
+		c.Done()
+		return
+	}
+
+	data, jerr := json.Marshal(rows)
+	if jerr != nil {
+		c.Data(500, "text/plain", []byte(jerr.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
 // @Summary Save Query
@@ -152,38 +143,36 @@ func ExecuteQueryLiteralHandler(d **database.DbManager) gin.HandlerFunc {
 // @Router /query/{qid} [post]
 
 // Save a custom query to the database
-func SaveQueryHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		query_name := c.Param("qid")
+func (server *Server) SaveQueryHandler(c *gin.Context) {
+	query_name := c.Param("qid")
 
-		// To prevent the query from being inaccessible later on, we need to sanitize
-		// If the query name can be parsed to an integer, reject it. It will clash with the ID, the user may accidentally select the wrong thing.
-		_, err := strconv.Atoi(query_name)
-		// If there is NO error parsing to integer, then we raise our own error
-		if err == nil {
-			c.Data(400, "text/plain", []byte("The query name must not be an integer!"))
-			c.Done()
-			return
-		}
-
-		data, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		// Inserting custom query
-		id, err := d.InsertCustomQuery(query_name, string(data))
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+	// To prevent the query from being inaccessible later on, we need to sanitize
+	// If the query name can be parsed to an integer, reject it. It will clash with the ID, the user may accidentally select the wrong thing.
+	_, err := strconv.Atoi(query_name)
+	// If there is NO error parsing to integer, then we raise our own error
+	if err == nil {
+		c.Data(400, "text/plain", []byte("The query name must not be an integer!"))
 		c.Done()
+		return
 	}
+
+	data, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	// Inserting custom query
+	id, err := server.Db.InsertCustomQuery(query_name, string(data))
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	c.Data(200, "text/plain", []byte(strconv.Itoa(id)))
+	c.Done()
 }
 
 // Delete a query
@@ -195,73 +184,69 @@ func SaveQueryHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 500 {string} string "Internal Server Error"
 // @Param qid query string type "Query name or ID"
 // @Router /query/{qid} [delete]
-func DeleteQueryHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		query_id_str := c.Param("qid")
+func (server *Server) DeleteQueryHandler(c *gin.Context) {
+	query_id_str := c.Param("qid")
 
-		q_err := d.DeleteCustomQuery(query_id_str)
-		if q_err != nil {
-			c.Data(500, "text/plain", []byte(q_err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Status(200)
+	q_err := server.Db.DeleteCustomQuery(query_id_str)
+	if q_err != nil {
+		c.Data(500, "text/plain", []byte(q_err.Error()))
 		c.Done()
+		return
 	}
+
+	c.Status(200)
+	c.Done()
 }
 
-func UpdateQueryHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		query_id, err := strconv.Atoi(c.Param("qid"))
-		if err != nil {
-			c.Data(400, "text/plain", []byte("Invalid query ID"))
-			c.Done()
-			return
-		}
+func (server *Server) UpdateQueryHandler(c *gin.Context) {
+	query_id, err := strconv.Atoi(c.Param("qid"))
+	if err != nil {
+		c.Data(400, "text/plain", []byte("Invalid query ID"))
+		c.Done()
+		return
+	}
 
-		data, err := io.ReadAll(c.Request.Body)
-		if err != nil {
+	data, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
+	}
+
+	var req struct {
+		Name    *string `json:"name"`
+		Literal *string `json:"literal"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		c.Data(400, "text/plain", []byte("Invalid JSON"))
+		c.Done()
+		return
+	}
+
+	// If the request does not contain any fields, return an error
+	if req.Name == nil && req.Literal == nil {
+		c.Data(400, "text/plain", []byte("At least one field must be provided"))
+		c.Done()
+		return
+	}
+
+	if req.Name != nil {
+		if err := server.Db.UpdateCustomQueryName(query_id, *req.Name); err != nil {
 			c.Data(500, "text/plain", []byte(err.Error()))
 			c.Done()
 			return
 		}
-
-		var req struct {
-			Name    *string `json:"name"`
-			Literal *string `json:"literal"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			c.Data(400, "text/plain", []byte("Invalid JSON"))
-			c.Done()
-			return
-		}
-
-		// If the request does not contain any fields, return an error
-		if req.Name == nil && req.Literal == nil {
-			c.Data(400, "text/plain", []byte("At least one field must be provided"))
-			c.Done()
-			return
-		}
-
-		if req.Name != nil {
-			if err := d.UpdateCustomQueryName(query_id, *req.Name); err != nil {
-				c.Data(500, "text/plain", []byte(err.Error()))
-				c.Done()
-				return
-			}
-		}
-		if req.Literal != nil {
-			if err := d.UpdateCustomQueryLiteral(query_id, *req.Literal); err != nil {
-				c.Data(500, "text/plain", []byte(err.Error()))
-				c.Done()
-				return
-			}
-		}
-
-		c.Status(200)
-		c.Done()
 	}
+	if req.Literal != nil {
+		if err := server.Db.UpdateCustomQueryLiteral(query_id, *req.Literal); err != nil {
+			c.Data(500, "text/plain", []byte(err.Error()))
+			c.Done()
+			return
+		}
+	}
+
+	c.Status(200)
+	c.Done()
 }
 
 // @Summary Retrieve the database schema to be provided to the AI LLM
@@ -270,15 +255,13 @@ func UpdateQueryHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {string} string "OK"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /api/cdb-schema [get]
-func SchemaDump(cdb **database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		str, err := (*cdb).DumpSchema()
-		if err != nil {
-			c.Data(500, "text/plain", []byte(err.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "text/plain", []byte(str))
+func (server *Server) SchemaDump(c *gin.Context) {
+	str, err := server.ClientDb.DumpSchema()
+	if err != nil {
+		c.Data(500, "text/plain", []byte(err.Error()))
+		c.Done()
+		return
 	}
+
+	c.Data(200, "text/plain", []byte(str))
 }

--- a/pkg/api/queries.go
+++ b/pkg/api/queries.go
@@ -103,16 +103,16 @@ func (server *Server) ExecuteQueryHandler(c *gin.Context) {
 	c.Done()
 }
 
-func executeQuery(d *database.DbManager, cdb **database.DbManager, queryID int) ([]map[string]string, error) {
+func (server *Server) executeQuery(queryID int) ([]map[string]string, error) {
 
 	// Get the query string from the database
-	_, query_string, serr := d.GetCustomQuery(strconv.Itoa(queryID))
+	_, query_string, serr := server.Db.GetCustomQuery(strconv.Itoa(queryID))
 	if serr != nil {
 		return nil, serr
 	}
 
 	// Execute the query
-	rows, qerr := (*cdb).ExecuteCustomQuery(query_string)
+	rows, qerr := server.ClientDb.ExecuteCustomQuery(query_string)
 	if qerr != nil {
 		return nil, qerr
 	}

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -36,17 +36,15 @@ func (rUpdate *RoleUpdateRequest) ToRole() database.Role {
 // @Success 200 {object} []database.Role "Successfully retrieved roles with user counts"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /roles [get]
-func GetRolesHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		roles, err := d.GetRoles()
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get roles: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.JSON(http.StatusOK, roles)
+func (server *Server) GetRolesHandler(c *gin.Context) {
+	roles, err := server.Db.GetRoles()
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get roles: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.JSON(http.StatusOK, roles)
 }
 
 // Add a new role to the database using the 'rname' route parameter.
@@ -61,25 +59,23 @@ func GetRolesHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request - Invalid JSON format"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /role [post]
-func AddRoleHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		var newRole database.Role
-		err := c.ShouldBindJSON(&newRole)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to bind role to JSON: %s", err.Error())
-			c.String(http.StatusBadRequest, errMsg)
-			return
-		}
-
-		_, err = d.AddRole(newRole)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to add role: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
+func (server *Server) AddRoleHandler(c *gin.Context) {
+	var newRole database.Role
+	err := c.ShouldBindJSON(&newRole)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to bind role to JSON: %s", err.Error())
+		c.String(http.StatusBadRequest, errMsg)
+		return
 	}
+
+	_, err = server.Db.AddRole(newRole)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to add role: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 // Update an existing role using the 'rid' route parameter.
@@ -95,34 +91,32 @@ func AddRoleHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request - Invalid role ID or JSON format"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /role/{rid} [patch]
-func UpdateRoleHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		roleIdStr := c.Param("rid")
-		roleId, err := strconv.Atoi(roleIdStr)
-		if err != nil {
-			errMsg := fmt.Sprintf("role id not provided as route parameter: %s", err.Error())
-			c.String(http.StatusBadRequest, errMsg)
-			return
-		}
-
-		// Bind JSON request body
-		var roleUpdate RoleUpdateRequest
-		err = c.ShouldBindJSON(&roleUpdate)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to bind request JSON body: %s", err.Error())
-			c.String(http.StatusBadRequest, errMsg)
-			return
-		}
-
-		err = d.UpdateRole(roleUpdate.ToRole())
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to update role '%d': %s", roleId, err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
+func (server *Server) UpdateRoleHandler(c *gin.Context) {
+	roleIdStr := c.Param("rid")
+	roleId, err := strconv.Atoi(roleIdStr)
+	if err != nil {
+		errMsg := fmt.Sprintf("role id not provided as route parameter: %s", err.Error())
+		c.String(http.StatusBadRequest, errMsg)
+		return
 	}
+
+	// Bind JSON request body
+	var roleUpdate RoleUpdateRequest
+	err = c.ShouldBindJSON(&roleUpdate)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to bind request JSON body: %s", err.Error())
+		c.String(http.StatusBadRequest, errMsg)
+		return
+	}
+
+	err = server.Db.UpdateRole(roleUpdate.ToRole())
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to update role '%d': %s", roleId, err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 // Delete a role, using `rid` route parameter.
@@ -136,21 +130,19 @@ func UpdateRoleHandler(d *database.DbManager) gin.HandlerFunc {
 // @Failure 400 {string} string "Bad Request - Invalid role ID"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /role/{rid} [delete]
-func DeleteRoleHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		roleId, err := strconv.Atoi(c.Param("rid"))
-		if err != nil {
-			c.String(http.StatusBadRequest, "unable to convert role id to int")
-			return
-		}
-
-		err = d.DeleteRole(roleId)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to delete role: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
+func (server *Server) DeleteRoleHandler(c *gin.Context) {
+	roleId, err := strconv.Atoi(c.Param("rid"))
+	if err != nil {
+		c.String(http.StatusBadRequest, "unable to convert role id to int")
+		return
 	}
+
+	err = server.Db.DeleteRole(roleId)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to delete role: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -39,50 +39,48 @@ const uuidTag = "uuid"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /login [post]
-func LoginHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		login := database.User{}
-		err := c.ShouldBindJSON(&login)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-
-		user, err := d.GetSingleUser(login.Name)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-
-		err = auth.AuthenticateUser(user.Password, login.Password)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-
-		isAdmin, err := d.IsUserAdmin(user)
-		if err != nil {
-			errMsg := fmt.Sprintf("internal server error: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		newId := addNewUUID(user.Id, user.Name, isAdmin, activeUsers)
-		c.SetCookie(
-			uuidTag,
-			newId,
-			int(24*time.Hour.Seconds()),
-			"/",
-			c.Request.Host,
-			false,
-			true,
-		)
-
-		body := map[string]bool{
-			"isAdmin": isAdmin,
-		}
-		c.JSON(http.StatusOK, body)
+func (server *Server) LoginHandler(c *gin.Context) {
+	login := database.User{}
+	err := c.ShouldBindJSON(&login)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
 	}
+
+	user, err := server.Db.GetSingleUser(login.Name)
+	if err != nil {
+		c.Status(http.StatusUnauthorized)
+		return
+	}
+
+	err = auth.AuthenticateUser(user.Password, login.Password)
+	if err != nil {
+		c.Status(http.StatusUnauthorized)
+		return
+	}
+
+	isAdmin, err := server.Db.IsUserAdmin(user)
+	if err != nil {
+		errMsg := fmt.Sprintf("internal server error: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	newId := server.addNewUUID(user.Id, user.Name, isAdmin)
+	c.SetCookie(
+		uuidTag,
+		newId,
+		int(24*time.Hour.Seconds()),
+		"/",
+		c.Request.Host,
+		false,
+		true,
+	)
+
+	body := map[string]bool{
+		"isAdmin": isAdmin,
+	}
+	c.JSON(http.StatusOK, body)
 }
 
 // Log out a user, delete their session UUID from the hash map
@@ -95,23 +93,21 @@ func LoginHandler(d *database.DbManager, activeUsers map[string]UserSessionData)
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 204 {string} string "No Content"
 // @Router /logout [post]
-func LogoutHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		id, err := c.Cookie(uuidTag)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-
-		_, exists := activeUsers[id]
-		if !exists {
-			c.Status(http.StatusNoContent)
-			return
-		}
-
-		delete(activeUsers, id)
-		c.Status(http.StatusOK)
+func (server *Server) LogoutHandler(c *gin.Context) {
+	id, err := c.Cookie(uuidTag)
+	if err != nil {
+		c.Status(http.StatusUnauthorized)
+		return
 	}
+
+	_, exists := server.ActiveUsers[id]
+	if !exists {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	delete(server.ActiveUsers, id)
+	c.Status(http.StatusOK)
 }
 
 // Check if the UUID cookie is set and valid
@@ -124,25 +120,23 @@ func LogoutHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 204 {string} string "No Content"
 // @Router /auth [get]
-func AuthHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		userUUID, err := c.Cookie(uuidTag)
-		if err != nil {
-			errMsg := fmt.Sprintf("expected a uuid cookie: %s", err.Error())
-			c.String(http.StatusBadRequest, errMsg)
-			c.Abort()
-			return
-		}
-
-		_, exists := activeUsers[userUUID]
-		if !exists {
-			c.String(http.StatusUnauthorized, "uuid not valid")
-			c.Abort()
-			return
-		}
-
-		c.Next()
+func (server *Server) AuthHandler(c *gin.Context) {
+	userUUID, err := c.Cookie(uuidTag)
+	if err != nil {
+		errMsg := fmt.Sprintf("expected a uuid cookie: %s", err.Error())
+		c.String(http.StatusBadRequest, errMsg)
+		c.Abort()
+		return
 	}
+
+	_, exists := server.ActiveUsers[userUUID]
+	if !exists {
+		c.String(http.StatusUnauthorized, "uuid not valid")
+		c.Abort()
+		return
+	}
+
+	c.Next()
 }
 
 // Check if a user is an admin
@@ -156,18 +150,16 @@ func AuthHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 // @Failure      400 {string} string "Bad Request"
 // @Failure      404 {string} string "User Not Found"
 // @Router       /api/isadmin/{uname} [get]
-func IsAdminHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		userName := c.Param("uname")
-		if userName == "" {
-			c.String(http.StatusBadRequest, "expected a `:uname` route parameter")
-		}
+func (server *Server) IsAdminHandler(c *gin.Context) {
+	userName := c.Param("uname")
+	if userName == "" {
+		c.String(http.StatusBadRequest, "expected a `:uname` route parameter")
+	}
 
-		for _, user := range activeUsers {
-			if user.Name == userName {
-				respBody := gin.H{"isAdmin": user.IsAdmin}
-				c.JSON(http.StatusOK, respBody)
-			}
+	for _, user := range server.ActiveUsers {
+		if user.Name == userName {
+			respBody := gin.H{"isAdmin": user.IsAdmin}
+			c.JSON(http.StatusOK, respBody)
 		}
 	}
 }
@@ -180,7 +172,7 @@ func IsAdminHandler(activeUsers map[string]UserSessionData) gin.HandlerFunc {
 // @Produce json
 // @Success 200 {object} object{message=string} "Returns message: pong"
 // @Router /ping [get]
-func PingHandler(c *gin.Context) {
+func (server *Server) PingHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": "pong",
 	})
@@ -191,85 +183,83 @@ type Message struct {
 	Content string `json:"content"`
 }
 
-func StrataBotHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// 1. Decode incoming request body into messages slice
-		var incoming struct {
-			Messages []Message `json:"messages"`
-		}
-		if err := c.BindJSON(&incoming); err != nil {
-			log.Printf("invalid request payload: %v", err)
-			c.JSON(http.StatusBadRequest, err.Error())
-			return
-		}
-
-		ollama_model, err := d.GetSetting("ollama_model")
-		if err != nil {
-			log.Printf("model lookup error: %v", err)
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		// 2. Build chat payload
-		payload := map[string]interface{}{
-			"model":    ollama_model,
-			"messages": incoming.Messages,
-			"stream":   false,
-		}
-		jsonBody, err := json.Marshal(payload)
-		if err != nil {
-			log.Printf("marshal error: %v", err)
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		// 3. Get host
-		ollama_host, err := d.GetSetting("ollama_host")
-		if err != nil {
-			log.Printf("host lookup error: %v", err)
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		// 4. Send chat request
-		resp, err := http.Post("http://"+ollama_host+"/api/chat",
-			"application/json", bytes.NewReader(jsonBody))
-		if err != nil {
-			log.Printf("request error: %v", err)
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-		defer resp.Body.Close()
-
-		// 5. Decode response
-		var respData struct {
-			Message Message `json:"message"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
-			log.Printf("decode error: %v", err)
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		// 6. Forward response message object(s)
-		c.JSON(http.StatusOK, respData.Message)
+func (server *Server) StrataBotHandler(c *gin.Context) {
+	// 1. Decode incoming request body into messages slice
+	var incoming struct {
+		Messages []Message `json:"messages"`
 	}
+	if err := c.BindJSON(&incoming); err != nil {
+		log.Printf("invalid request payload: %v", err)
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ollama_model, err := server.Db.GetSetting("ollama_model")
+	if err != nil {
+		log.Printf("model lookup error: %v", err)
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// 2. Build chat payload
+	payload := map[string]interface{}{
+		"model":    ollama_model,
+		"messages": incoming.Messages,
+		"stream":   false,
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("marshal error: %v", err)
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// 3. Get host
+	ollama_host, err := server.Db.GetSetting("ollama_host")
+	if err != nil {
+		log.Printf("host lookup error: %v", err)
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// 4. Send chat request
+	resp, err := http.Post("http://"+ollama_host+"/api/chat",
+		"application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		log.Printf("request error: %v", err)
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	// 5. Decode response
+	var respData struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+		log.Printf("decode error: %v", err)
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// 6. Forward response message object(s)
+	c.JSON(http.StatusOK, respData.Message)
 }
 
 // Generate UUID if user does not already have one
-func addNewUUID(userId int, username string, isAdmin bool, users map[string]UserSessionData) string {
-	for sessionUUID, session := range users {
+func (server *Server) addNewUUID(userId int, username string, isAdmin bool) string {
+	for sessionUUID, session := range server.ActiveUsers {
 		if userId == session.Id {
 			return sessionUUID
 		}
 	}
 
 	newUUId := uuid.NewString()
-	for _, ok := users[newUUId]; ok; {
+	for _, ok := server.ActiveUsers[newUUId]; ok; {
 		newUUId = uuid.NewString()
 	}
 
-	users[newUUId] = UserSessionData{
+	server.ActiveUsers[newUUId] = UserSessionData{
 		Id:      userId,
 		Name:    username,
 		IsAdmin: isAdmin,
@@ -278,77 +268,71 @@ func addNewUUID(userId int, username string, isAdmin bool, users map[string]User
 	return newUUId
 }
 
-func GetAllSettingsHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		settings, err := d.ExecuteCustomQuery("SELECT skey, svalue FROM settings;")
-		if err != nil {
-			errMsg := fmt.Sprintf("Unable to get all settings: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
+func (server *Server) GetAllSettingsHandler(c *gin.Context) {
+	settings, err := server.Db.ExecuteCustomQuery("SELECT skey, svalue FROM settings;")
+	if err != nil {
+		errMsg := fmt.Sprintf("Unable to get all settings: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
 
-		// Convert the resulting object to JSON
-		data, jerr := json.Marshal(settings)
-		if jerr != nil {
-			c.Data(500, "text/plain", []byte(jerr.Error()))
-			c.Done()
-			return
-		}
-
-		c.Data(200, "application/json", data)
+	// Convert the resulting object to JSON
+	data, jerr := json.Marshal(settings)
+	if jerr != nil {
+		c.Data(500, "text/plain", []byte(jerr.Error()))
 		c.Done()
+		return
 	}
+
+	c.Data(200, "application/json", data)
+	c.Done()
 }
 
-func GetSettingHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		key := c.Param("key")
+func (server *Server) GetSettingHandler(c *gin.Context) {
+	key := c.Param("key")
 
-		settings, err := d.GetSetting(key)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get settings: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.JSON(http.StatusOK, settings)
+	settings, err := server.Db.GetSetting(key)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get settings: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.JSON(http.StatusOK, settings)
 }
 
-func UpdateSettingHandler(d *database.DbManager, cdb **database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		key := c.Param("key")
+func (server *Server) UpdateSettingHandler(c *gin.Context) {
+	key := c.Param("key")
 
-		bodyBytes, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to read request body: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		err = d.SetSetting(key, string(bodyBytes))
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to update settings: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		if key == "cdb" {
-			// Disconnect from the client database, then reconnect to this new database
-			if *cdb != nil {
-				(*cdb).Connection.Close()
-				*cdb = nil
-			}
-
-			// Attempt to connect to new database so you don't have to restart the server
-			*cdb, err = database.NewDbManager(string(bodyBytes), context.Background())
-			if err != nil {
-				errMsg := fmt.Sprintf("Unable to connect to new database: %s", err.Error())
-				c.String(http.StatusInternalServerError, errMsg)
-				return
-			}
-		}
-
-		c.Status(http.StatusOK)
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to read request body: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	err = server.Db.SetSetting(key, string(bodyBytes))
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to update settings: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	if key == "cdb" {
+		// Disconnect from the client database, then reconnect to this new database
+		if server.ClientDb != nil {
+			server.ClientDb.Connection.Close()
+			server.ClientDb = nil
+		}
+
+		// Attempt to connect to new database so you don't have to restart the server
+		server.ClientDb, err = database.NewDbManager(string(bodyBytes), context.Background())
+		if err != nil {
+			errMsg := fmt.Sprintf("Unable to connect to new database: %s", err.Error())
+			c.String(http.StatusInternalServerError, errMsg)
+			return
+		}
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/TeamStrata/strata/pkg/database"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+type Server struct {
+	Engine      *gin.Engine
+	Db          *database.DbManager
+	ClientDb    *database.DbManager
+	ActiveUsers map[string]UserSessionData
+}
+
+// Initialize server engine and database manager.
+func InitServer() (*Server, error) {
+	engine := gin.Default()
+
+	//cors config (redux)
+	config := cors.Config{
+		AllowOrigins:     []string{"http://localhost:5173"},
+		AllowMethods:     []string{"GET", "PATCH", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
+		AllowCredentials: true,
+		MaxAge:           12 * time.Hour,
+	}
+	engine.Use(cors.New(config))
+
+	// Get database connection string
+	conStr, err := database.GetConnectionString(database.DefaultPath)
+	if err != nil {
+		log.Fatalf("error loading .env file: %s", err.Error())
+		return nil, err
+	}
+
+	// Initialize database manager
+	db, err := database.NewDbManager(conStr, context.Background())
+	if err != nil {
+		log.Fatalf("error initializing DB manager: %s", err.Error())
+		return nil, err
+	}
+
+	// Create the client database which will be used for custom queries
+	cdb_str, err := db.GetSetting("cdb")
+	if err != nil {
+		log.Printf("error reading DB settings: %s", err.Error())
+		return nil, err
+	}
+
+	clientDb, err := database.NewDbManager(cdb_str, context.Background())
+	if err != nil {
+		log.Printf("error initializing client DB manager: %s", err.Error())
+		return nil, err
+	}
+
+	ActiveUsers := make(map[string]UserSessionData)
+	server := Server{
+		engine,
+		db,
+		clientDb,
+		ActiveUsers,
+	}
+
+	return &server, nil
+}

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -23,48 +23,46 @@ import (
 // @Failure 400 {string} string "Bad Request - Invalid JSON format"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /signup [post]
-func SignUpHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		user := database.User{}
-		err := c.ShouldBindJSON(&user)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
-			return
-		}
-
-		hash, err := auth.HashPassword(user.Password)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to hash provided password: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		user, err = d.InsertUser(user.Name, hash)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to add user to database: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		isAdmin, err := d.IsUserAdmin(user)
-		if err != nil {
-			errMsg := fmt.Sprintf("internal server error: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		newId := addNewUUID(user.Id, user.Name, isAdmin, activeUsers)
-		c.SetCookie(
-			uuidTag,
-			newId,
-			int(24*time.Hour.Seconds()),
-			"/",
-			"localhost",
-			false,
-			true,
-		)
-		c.Status(http.StatusOK)
+func (server *Server) SignUpHandler(c *gin.Context) {
+	user := database.User{}
+	err := c.ShouldBindJSON(&user)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
 	}
+
+	hash, err := auth.HashPassword(user.Password)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to hash provided password: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	user, err = server.Db.InsertUser(user.Name, hash)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to add user to database: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	isAdmin, err := server.Db.IsUserAdmin(user)
+	if err != nil {
+		errMsg := fmt.Sprintf("internal server error: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	newId := server.addNewUUID(user.Id, user.Name, isAdmin)
+	c.SetCookie(
+		uuidTag,
+		newId,
+		int(24*time.Hour.Seconds()),
+		"/",
+		"localhost",
+		false,
+		true,
+	)
+	c.Status(http.StatusOK)
 }
 
 // Respond with JSON representation of all users
@@ -77,22 +75,20 @@ func SignUpHandler(d *database.DbManager, activeUsers map[string]UserSessionData
 // @Failure 204 {string} string "No Content - No users found"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /users [get]
-func GetUsersHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		users, err := d.GetAllUsers()
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get users: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		if len(users) <= 0 {
-			c.Status(http.StatusNoContent)
-			return
-		}
-
-		c.JSON(http.StatusOK, users)
+func (server *Server) GetUsersHandler(c *gin.Context) {
+	users, err := server.Db.GetAllUsers()
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get users: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	if len(users) <= 0 {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	c.JSON(http.StatusOK, users)
 }
 
 // Respond with JSON representation of all users
@@ -105,19 +101,17 @@ func GetUsersHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {object} database.User "Successfully retrieved user"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uid} [get]
-func GetUserHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		user_id_str := c.Param("uid")
-		user, err := d.GetSingleUser(user_id_str)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to get user: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.JSON(http.StatusOK, user)
-		c.Done()
+func (server *Server) GetUserHandler(c *gin.Context) {
+	user_id_str := c.Param("uid")
+	user, err := server.Db.GetSingleUser(user_id_str)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to get user: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.JSON(http.StatusOK, user)
+	c.Done()
 }
 
 // Delete a user that matches the name parameter
@@ -130,26 +124,24 @@ func GetUserHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {string} string "User deleted successfully"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uname} [delete]
-func DeleteUserHandler(d *database.DbManager, activeUsers map[string]UserSessionData) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		name := c.Param("uname")
+func (server *Server) DeleteUserHandler(c *gin.Context) {
+	name := c.Param("uname")
 
-		for id, user := range activeUsers {
-			if user.Name == name {
-				delete(activeUsers, id)
-				break
-			}
+	for id, user := range server.ActiveUsers {
+		if user.Name == name {
+			delete(server.ActiveUsers, id)
+			break
 		}
-
-		err := d.DeleteUser(name)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to delete user: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
 	}
+
+	err := server.Db.DeleteUser(name)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to delete user: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
 // Update an existing user using the 'uid' route parameter.
@@ -165,41 +157,38 @@ func DeleteUserHandler(d *database.DbManager, activeUsers map[string]UserSession
 // @Failure 400 {string} string "Bad Request - Invalid user ID or JSON format"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uid} [patch]
-func UpdateUserHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
+func (server *Server) UpdateUserHandler(c *gin.Context) {
+	// handle route params
+	uid, err := strconv.Atoi(c.Param("uid"))
 
-		// handle route params
-		uid, err := strconv.Atoi(c.Param("uid"))
+	if err != nil {
+		c.String(http.StatusBadRequest, "uid not specified in request")
+	}
 
-		if err != nil {
-			c.String(http.StatusBadRequest, "uid not specified in request")
-		}
+	// handle body
+	var newUserData database.User
 
-		// handle body
-		var newUserData database.User
+	err = c.ShouldBindJSON(&newUserData)
+	if err != nil {
+		msg := fmt.Sprintf("Error reading body: %s", err.Error())
+		c.String(http.StatusBadRequest, msg)
+	}
 
-		err = c.ShouldBindJSON(&newUserData)
-		if err != nil {
-			msg := fmt.Sprintf("Error reading body: %s", err.Error())
-			c.String(http.StatusBadRequest, msg)
-		}
+	password_hash := ""
+	if newUserData.Password != "" {
+		password_hash, err = auth.HashPassword(newUserData.Password)
+	}
 
-		password_hash := ""
-		if newUserData.Password != "" {
-			password_hash, err = auth.HashPassword(newUserData.Password)
-		}
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to hash provided password: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
+	}
 
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to hash provided password: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		err = d.UpdateUser(uid, newUserData.Name, password_hash)
-		if err != nil {
-			errMsg := fmt.Sprintf("unable to update user '%d': %s", uid, err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-		}
+	err = server.Db.UpdateUser(uid, newUserData.Name, password_hash)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to update user '%d': %s", uid, err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
 	}
 }
 
@@ -214,22 +203,20 @@ func UpdateUserHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {string} string "Role assigned successfully"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uname}/role/{rname} [post]
-func AddUserRoleHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		userName := c.Param("uname")
-		roleName := c.Param("rname")
+func (server *Server) AddUserRoleHandler(c *gin.Context) {
+	userName := c.Param("uname")
+	roleName := c.Param("rname")
 
-		err := d.AddUserRole(userName, roleName)
-		if err != nil {
-			// This errMsg needs to be more descriptive based on the actual error.
-			// For now, I'll leave it as a generic message.
-			errMsg := fmt.Sprintf("unable to add user role: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
+	err := server.Db.AddUserRole(userName, roleName)
+	if err != nil {
+		// This errMsg needs to be more descriptive based on the actual error.
+		// For now, I'll leave it as a generic message.
+		errMsg := fmt.Sprintf("unable to add user role: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.Status(http.StatusOK)
 }
 
 // Delete a role from a user
@@ -243,20 +230,18 @@ func AddUserRoleHandler(d *database.DbManager) gin.HandlerFunc {
 // @Success 200 {string} string "Role removed successfully"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /user/{uname}/role/{rname} [delete]
-func DeleteUserRoleHandler(d *database.DbManager) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		userName := c.Param("uname")
-		roleName := c.Param("rname")
+func (server *Server) DeleteUserRoleHandler(c *gin.Context) {
+	userName := c.Param("uname")
+	roleName := c.Param("rname")
 
-		err := d.DeleteUserRole(userName, roleName)
-		if err != nil {
-			// This errMsg needs to be more descriptive based on the actual error.
-			// For now, I'll leave it as a generic message.
-			errMsg := fmt.Sprintf("unable to delete user role: %s", err.Error())
-			c.String(http.StatusInternalServerError, errMsg)
-			return
-		}
-
-		c.Status(http.StatusOK)
+	err := server.Db.DeleteUserRole(userName, roleName)
+	if err != nil {
+		// This errMsg needs to be more descriptive based on the actual error.
+		// For now, I'll leave it as a generic message.
+		errMsg := fmt.Sprintf("unable to delete user role: %s", err.Error())
+		c.String(http.StatusInternalServerError, errMsg)
+		return
 	}
+
+	c.Status(http.StatusOK)
 }


### PR DESCRIPTION
## Changes made
This refactor involved wrapping the DbManager, *gin.Engine, and user session data in a `Server` struct.
- Cleans up the API route functions a lot.
- Eliminates the need to pass DbManager and user session data to API handler functions.

```go
type Server struct {
	Engine      *gin.Engine
	Db          *database.DbManager
	ClientDb    *database.DbManager
	ActiveUsers map[string]UserSessionData
}
```